### PR TITLE
viewport meta should not be in document

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,6 +2,7 @@ import '../styles/global.css';
 import React, { useState } from 'react';
 import { AppContext } from '../contexts/appContext';
 import type { AppProps } from 'next/app';
+import Head from 'next/head';
 import ProgressBar from '../components/progressBar';
 import { Toaster } from 'react-hot-toast';
 
@@ -9,12 +10,17 @@ export default function MyApp({ Component, pageProps }: AppProps) {
   const [isLoading, setIsLoading] = useState<boolean>();
 
   return (
-    <AppContext.Provider value={{
-      setIsLoading: setIsLoading,
-    }}>
-      <ProgressBar isLoading={isLoading} />
-      <Toaster toastOptions={{ duration: 1500 }}/>
-      <Component {...pageProps} />
-    </AppContext.Provider>
+    <>
+      <Head>
+        <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0' />
+      </Head>
+      <AppContext.Provider value={{
+        setIsLoading: setIsLoading,
+      }}>
+        <ProgressBar isLoading={isLoading} />
+        <Toaster toastOptions={{ duration: 1500 }}/>
+        <Component {...pageProps} />
+      </AppContext.Provider>
+    </>
   );
 }

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -17,7 +17,6 @@ class MyDocument extends Document {
           <link href='/favicon.png' rel='icon' />
           <meta name='theme-color' content='#000000' />
           <meta name='description' content='Pathology' />
-          <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0"></meta>
         </Head>
         <body className='theme-modern'>
           <Main />


### PR DESCRIPTION
Fixes this warning:

`Warning: viewport meta tags should not be used in _document.js's <Head>. https://nextjs.org/docs/messages/no-document-viewport-meta`