### PR TITLE
Remove hooks from coverage

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -23,6 +23,8 @@ export default {
   // An array of glob patterns indicating a set of files for which coverage information should be collected
   collectCoverageFrom: [
     '**/*.ts',
+    // ignore hooks
+    '!hooks/**',
     // ignore server helper files
     '!server/**',
     // ignore declaration files


### PR DESCRIPTION
Hooks must be called within a component, so for now avoid testing them. Also the majority of hooks are just helper functions that call `useSWRHelper`.

```
    Warning: Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:
    1. You might have mismatching versions of React and the renderer (such as React DOM)
    2. You might be breaking the Rules of Hooks
    3. You might have more than one copy of React in the same app
    See https://reactjs.org/link/invalid-hook-call for tips about how to debug and fix this problem.
```