### PR TITLE
Fix rare identical ts bug

### DIFF
--- a/pages/api/level/[id].ts
+++ b/pages/api/level/[id].ts
@@ -138,7 +138,7 @@ export default withAuth({
       });
     }
 
-    const record = await RecordModel.findOne<Record>({ levelId: id }).sort({ ts: -1 });
+    const record = await RecordModel.findOne<Record>({ levelId: id }).sort({ moves: 1 });
 
     // update calc_records if the record was set by a different user
     if (record && record.userId.toString() !== req.userId) {

--- a/tests/pages/api/level/level.byid.test.ts
+++ b/tests/pages/api/level/level.byid.test.ts
@@ -669,7 +669,7 @@ describe('pages/api/level/index.ts', () => {
       _id: new ObjectId(),
       levelId: test_level_id,
       moves: 20,
-      ts: TimerUtil.getTs() - 1,
+      ts: TimerUtil.getTs(),
       userId: TestId.USER,
     });
 


### PR DESCRIPTION
If a level has records with identical ts, deleting the level may not update calc_records correctly