### PR TITLE
fix playattempt bugs

### DIFF
--- a/pages/api/publish/[id].ts
+++ b/pages/api/publish/[id].ts
@@ -156,7 +156,7 @@ export default withAuth({ POST: {
           ts: ts,
           userId: new Types.ObjectId(req.userId),
         }], { session: session }),
-        ...issueAchievements(req.user._id, req.user.score + 1, { session: session }),
+        issueAchievements(req.user._id, req.user.score + 1, { session: session }),
       ]);
 
       if (!updatedLevel) {

--- a/pages/api/stats/index.ts
+++ b/pages/api/stats/index.ts
@@ -1,5 +1,7 @@
 import AchievementInfo from '@root/constants/achievementInfo';
+import getDifficultyEstimate from '@root/helpers/getDifficultyEstimate';
 import User from '@root/models/db/user';
+import { AttemptContext } from '@root/models/schemas/playAttemptSchema';
 import mongoose, { SaveOptions, Types } from 'mongoose';
 import type { NextApiResponse } from 'next';
 import AchievementType from '../../../constants/achievementType';
@@ -11,27 +13,21 @@ import { logger } from '../../../helpers/logger';
 import { createNewAchievement, createNewRecordOnALevelYouBeatNotifications } from '../../../helpers/notificationHelper';
 import validateSolution from '../../../helpers/validateSolution';
 import withAuth, { NextApiRequestWithAuth } from '../../../lib/withAuth';
-import Level from '../../../models/db/level';
+import Level, { EnrichedLevel } from '../../../models/db/level';
 import Record from '../../../models/db/record';
 import Stat from '../../../models/db/stat';
 import { LevelModel, PlayAttemptModel, RecordModel, StatModel, UserModel } from '../../../models/mongoose';
-import { AttemptContext } from '../../../models/schemas/playAttemptSchema';
 import { queueRefreshIndexCalcs } from '../internal-jobs/worker';
 import { matchMarkCompleteLevel } from '../match/[matchId]';
-import { forceCompleteLatestPlayAttempt } from '../play-attempt';
 
-export function issueAchievements(userId: Types.ObjectId, score: number, options: SaveOptions) {
-  const promises = [];
-
+export async function issueAchievements(userId: Types.ObjectId, score: number, options: SaveOptions) {
   for (const achievementType in AchievementInfo) {
     const achievementInfo = AchievementInfo[achievementType];
 
     if (achievementInfo.exactlyUnlocked({ score: score } as User)) {
-      promises.push(createNewAchievement(achievementType as AchievementType, userId, options));
+      await createNewAchievement(achievementType as AchievementType, userId, options);
     }
   }
-
-  return promises;
 }
 
 export default withAuth({
@@ -59,9 +55,15 @@ export default withAuth({
       await session.withTransaction(async () => {
         const level = await LevelModel.findOne<Level>({ _id: levelId, isDeleted: { $ne: true } }, {}, { lean: true, session: session });
 
-        if (!level || (level.isDraft && level.userId.toString() !== req.userId)) {
+        if (!level) {
           resTrack.status = 404;
           resTrack.json.error = `Error finding level ${levelId}`;
+          throw new Error(resTrack.json.error);
+        }
+
+        if (level.isDraft && level.userId.toString() !== req.userId) {
+          resTrack.status = 401;
+          resTrack.json.error = `Unauthorized access for level ${levelId}`;
           throw new Error(resTrack.json.error);
         }
 
@@ -76,7 +78,7 @@ export default withAuth({
         // ensure no stats are saved for draft levels
         if (level.isDraft || level.leastMoves === 0) {
           if (moves < level.leastMoves || level.leastMoves === 0) {
-            await LevelModel.updateOne({ _id: levelId }, {
+            await LevelModel.updateOne({ _id: level._id }, {
               $set: { leastMoves: moves },
             }, { session: session });
           }
@@ -84,35 +86,34 @@ export default withAuth({
           return;
         }
 
-        const stat = await StatModel.findOne<Stat>({ levelId: levelId, userId: req.userId }, {}, { lean: true, session: session });
         const complete = moves <= level.leastMoves;
 
-        // TODO: if complete, and previously not complete, then call forceCompleteLatestPlayAttempt
-        // in the case of a record, we don't need to call forceCompleteLatestPlayAttempt early
-        // TODO: keep track of updates to UserModel and update all at once (currently may $inc twice)
+        if (complete && matchId) {
+          // TODO: use session here
+          await matchMarkCompleteLevel(req.user._id, matchId, level._id);
+        }
 
+        const stat = await StatModel.findOne<Stat>({ levelId: level._id, userId: req.user._id }, {}, { lean: true, session: session });
+
+        // level was previously solved and no personal best was set, only need to $inc attempts and return
+        if (stat && moves >= stat.moves) {
+          await StatModel.updateOne({ _id: stat._id }, { $inc: { attempts: 1 } }, { session: session });
+
+          return;
+        }
+
+        // track the new personal best in a stat
         if (!stat) {
-          // add the stat if it did not previously exist
           await StatModel.create([{
             _id: new Types.ObjectId(),
             attempts: 1,
             complete: complete,
-            levelId: new Types.ObjectId(levelId),
+            levelId: level._id,
             moves: moves,
             ts: ts,
-            userId: new Types.ObjectId(req.userId),
+            userId: req.user._id,
           }], { session: session });
-
-          if (complete) {
-            // NB: await to avoid multiple user updates in parallel
-            await Promise.all([
-              UserModel.updateOne({ _id: req.userId }, { $inc: { score: 1 } }, { session: session }),
-              ...issueAchievements(req.user._id, req.user.score + 1, { session: session }),
-              forceCompleteLatestPlayAttempt(req.userId, levelId, ts, { session: session }),
-            ]);
-          }
-        } else if (moves < stat.moves) {
-          // update stat if it exists and a new personal best is set
+        } else {
           await StatModel.updateOne({ _id: stat._id }, {
             $inc: {
               attempts: 1,
@@ -122,24 +123,25 @@ export default withAuth({
               moves: moves,
               ts: ts,
             },
-          }, { session: session }).exec();
-
-          if (!stat.complete && complete) {
-            // NB: await to avoid multiple user updates in parallel
-            await UserModel.updateOne({ _id: req.userId }, { $inc: { score: 1 } }, { session: session });
-            await Promise.all([
-              ...issueAchievements(req.user._id, req.user.score + 1, { session: session }),
-              forceCompleteLatestPlayAttempt(req.userId, levelId, ts, { session: session }),
-            ]);
-          }
-        } else {
-          // increment attempts in all other cases
-          await StatModel.updateOne({ _id: stat._id }, { $inc: { attempts: 1 } }, { session: session });
+          }, { session: session });
         }
 
-        // if a new record was set
-        if (moves < level.leastMoves) {
-          const prevRecord = await RecordModel.findOne<Record>({ levelId: levelId }, {}, { session: session }).sort({ ts: -1 });
+        // if the level was not completed optimally, nothing more to be done
+        if (!complete) {
+          return;
+        }
+
+        // if the level was previously incomplete, increment score
+        if (!stat?.complete) {
+          await UserModel.updateOne({ _id: req.userId }, { $inc: { score: 1 } }, { session: session });
+          await issueAchievements(req.user._id, req.user.score + 1, { session: session });
+        }
+
+        const newRecord = moves < level.leastMoves;
+        let incPlayattemptsDurationSum = 0;
+
+        if (newRecord) {
+          const prevRecord = await RecordModel.findOne<Record>({ levelId: level._id }, {}, { session: session }).sort({ ts: -1 });
 
           // update calc_records if the previous record was set by a different user
           if (prevRecord && prevRecord.userId.toString() !== req.userId) {
@@ -157,62 +159,156 @@ export default withAuth({
             }
           }
 
-          // update level with new leastMoves data
-          await LevelModel.updateOne({ _id: levelId }, {
-            $set: {
-              leastMoves: moves,
-              // NB: set to 0 here because forceUpdateLatestPlayAttempt will increment to 1
-              calc_playattempts_just_beaten_count: 0,
-            },
-          }, { session: session });
           await RecordModel.create([{
             _id: new Types.ObjectId(),
-            levelId: new Types.ObjectId(levelId),
+            levelId: level._id,
             moves: moves,
             ts: ts,
-            userId: new Types.ObjectId(req.userId),
+            userId: req.user._id,
           }], { session: session });
-          await PlayAttemptModel.updateMany(
-            { levelId: new Types.ObjectId(levelId) },
-            { $set: { attemptContext: AttemptContext.UNBEATEN } },
-            { session: session },
-          );
-          await forceCompleteLatestPlayAttempt(req.userId, levelId, ts, { session: session });
-          // find the userIds that need to be updated
+
+          // find the stats and users that that need to be updated
           const stats = await StatModel.find<Stat>({
             complete: true,
-            levelId: new Types.ObjectId(levelId),
+            levelId: level._id,
             userId: { $ne: req.userId },
           }, 'userId', {
             lean: true,
             session: session,
           });
 
-          if (stats && stats.length > 0) {
-            // update all stats/users that had the record on this level
+          // update all stats/users that had the record on this level
+          if (stats.length > 0) {
             const statUserIds = stats.map(s => s.userId);
 
             await StatModel.updateMany(
-              { _id: { $in: stats.map(stat => stat._id) } },
-              { $set: { complete: false } }, { session: session }
+              { _id: { $in: stats.map(s => s._id) } },
+              { $set: { complete: false } },
+              { session: session },
             );
             await UserModel.updateMany(
-              { _id: { $in: statUserIds } }, { $inc: { score: -1 } }, { session: session }
+              { _id: { $in: statUserIds } },
+              { $inc: { score: -1 } },
+              { session: session },
             );
 
             // create a notification for each user
-            await createNewRecordOnALevelYouBeatNotifications(statUserIds, req.userId, levelId, moves.toString(), { session: session });
+            await createNewRecordOnALevelYouBeatNotifications(statUserIds, req.userId, level._id, moves.toString(), { session: session });
           }
 
-          await queueDiscordWebhook(Discord.LevelsId, `**${req.user?.name}** set a new record: [${level.name}](${req.headers.origin}/level/${level.slug}?ts=${ts}) - ${moves} moves`, { session: session });
+          // keep track of all playtime after the record was set
+          const sumDuration = await PlayAttemptModel.aggregate([
+            {
+              $match: {
+                levelId: level._id,
+                attemptContext: AttemptContext.BEATEN,
+              }
+            },
+            {
+              $group: {
+                _id: null,
+                sumDuration: {
+                  $sum: {
+                    $subtract: ['$endTime', '$startTime']
+                  }
+                }
+              }
+            }
+          ], { session: session });
+
+          incPlayattemptsDurationSum += sumDuration[0]?.sumDuration ?? 0;
+
+          // reset all playattempts to unbeaten
+          await PlayAttemptModel.updateMany(
+            { levelId: level._id },
+            { $set: { attemptContext: AttemptContext.UNBEATEN } },
+            { session: session },
+          );
+
+          await queueDiscordWebhook(Discord.LevelsId, `**${req.user.name}** set a new record: [${level.name}](${req.headers.origin}/level/${level.slug}?ts=${ts}) - ${moves} moves`, { session: session });
         }
+
+        // extend the user's recent playattempt up to current ts
+        const found = await PlayAttemptModel.findOneAndUpdate({
+          endTime: { $gt: ts - 3 * 60 },
+          levelId: level._id,
+          userId: req.user._id,
+        }, {
+          $set: {
+            attemptContext: AttemptContext.JUST_BEATEN,
+            endTime: ts,
+          },
+          $inc: { updateCount: 1 }
+        }, {
+          new: false,
+          lean: true,
+          session: session,
+          sort: {
+            endTime: -1,
+            // NB: if end time is identical, we want to get the highest attempt context (JUST_BEATEN over UNBEATEN)
+            attemptContext: -1,
+          },
+        });
+
+        if (!found) {
+          // create one if it did not exist... rare but possible
+          await PlayAttemptModel.create([{
+            _id: new Types.ObjectId(),
+            attemptContext: AttemptContext.JUST_BEATEN,
+            startTime: ts,
+            endTime: ts,
+            updateCount: 0,
+            levelId: level._id,
+            userId: req.user._id,
+          }], { session: session });
+        } else {
+          incPlayattemptsDurationSum += ts - found.endTime;
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const levelUpdate: mongoose.AnyKeys<any> = {
+          $addToSet: {
+            calc_playattempts_unique_users: req.user._id,
+          },
+          $inc: {
+            calc_playattempts_duration_sum: incPlayattemptsDurationSum,
+          },
+        };
+
+        if (newRecord) {
+          levelUpdate['$set'] = {
+            calc_playattempts_just_beaten_count: 1,
+            leastMoves: moves,
+          };
+        } else {
+          levelUpdate['$inc']['calc_playattempts_just_beaten_count'] = 1;
+        }
+
+        console.log(levelUpdate);
+
+        const enrichedLevel = await LevelModel.findByIdAndUpdate<EnrichedLevel>(level._id, levelUpdate, {
+          new: true,
+          lean: true,
+          projection: {
+            calc_playattempts_duration_sum: 1,
+            calc_playattempts_just_beaten_count: 1,
+            calc_playattempts_unique_users_count: { $size: '$calc_playattempts_unique_users' },
+          },
+          session: session,
+        });
+
+        // should be impossible, but need this check for typescript to be happy
+        if (!enrichedLevel) {
+          throw new Error('Level ' + levelId + ' not found within transaction');
+        }
+
+        await LevelModel.findByIdAndUpdate(level._id, {
+          $set: {
+            calc_difficulty_estimate: getDifficultyEstimate(enrichedLevel, enrichedLevel.calc_playattempts_unique_users_count ?? 0),
+          },
+        }, { session: session });
 
         await queueRefreshIndexCalcs(level._id, { session: session });
-
-        if (complete && matchId) {
-          // TODO: use session here
-          await matchMarkCompleteLevel(req.user._id, matchId, level._id);
-        }
       });
 
       resTrack.status = 200;

--- a/pages/api/stats/index.ts
+++ b/pages/api/stats/index.ts
@@ -284,8 +284,6 @@ export default withAuth({
           levelUpdate['$inc']['calc_playattempts_just_beaten_count'] = 1;
         }
 
-        console.log(levelUpdate);
-
         const enrichedLevel = await LevelModel.findByIdAndUpdate<EnrichedLevel>(level._id, levelUpdate, {
           new: true,
           lean: true,

--- a/tests/pages/api/play-attempt/play-attempt.test.ts
+++ b/tests/pages/api/play-attempt/play-attempt.test.ts
@@ -415,17 +415,12 @@ const tests = [
     name: 'CarlAndre bug',
     list: [
       ['play', 0, 'created'],
-      ['play', 15, 'updated'],
       ['play', 30, 'updated'],
       ['win_20', 30, ''],
       ['play', 41, 'created'],
-      ['play', 45, 'updated'],
-      ['play', 56, 'updated'],
-      ['play', 71, 'updated'],
       ['play', 86, 'updated'],
       ['win_10', 89, ''],
       ['play', 103, 'created'],
-      ['play', 109, 'updated'],
       ['play', 120, 'updated'],
       ['win_8', 125, ''],
     ],
@@ -435,12 +430,40 @@ const tests = [
       expect(lvl.calc_playattempts_duration_sum).toBe(100);
 
       expect(playAttemptDocs.length).toBe(3);
-      expect(playAttemptDocs[0].updateCount).toBe(3);
+      expect(playAttemptDocs[0].updateCount).toBe(2);
       expect(playAttemptDocs[0].attemptContext).toBe(AttemptContext.JUST_BEATEN);
-      expect(playAttemptDocs[1].updateCount).toBe(5);
+      expect(playAttemptDocs[1].updateCount).toBe(2);
       expect(playAttemptDocs[1].attemptContext).toBe(AttemptContext.UNBEATEN);
-      expect(playAttemptDocs[2].updateCount).toBe(3);
+      expect(playAttemptDocs[2].updateCount).toBe(2);
       expect(playAttemptDocs[2].attemptContext).toBe(AttemptContext.UNBEATEN);
+      expect(lvl.calc_playattempts_unique_users).toStrictEqual([new Types.ObjectId(TestId.USER)]);
+      expect(lvl.calc_playattempts_just_beaten_count).toBe(1);
+    }
+  },
+  {
+    levelId: TestId.LEVEL_4,
+    name: 'screwtape bug',
+    list: [
+      ['play', 0, 'created'],
+      ['play', 30, 'updated'],
+      ['win_10', 30, ''],
+      ['play', 41, 'created'],
+      ['play', 86, 'updated'],
+      ['win_10', 89, ''],
+      ['play', 103, 'updated'],
+      ['play', 120, 'updated'],
+      ['win_8', 125, ''],
+    ],
+    tests: async (playAttemptDocs: PlayAttempt[], statDocs: Stat[], lvl: Level) => {
+      expect(lvl.calc_playattempts_just_beaten_count).toBe(1);
+      // 0-30, 41-125
+      expect(lvl.calc_playattempts_duration_sum).toBe(114);
+
+      expect(playAttemptDocs.length).toBe(2);
+      expect(playAttemptDocs[0].updateCount).toBe(4);
+      expect(playAttemptDocs[0].attemptContext).toBe(AttemptContext.JUST_BEATEN);
+      expect(playAttemptDocs[1].updateCount).toBe(2);
+      expect(playAttemptDocs[1].attemptContext).toBe(AttemptContext.UNBEATEN);
       expect(lvl.calc_playattempts_unique_users).toStrictEqual([new Types.ObjectId(TestId.USER)]);
       expect(lvl.calc_playattempts_just_beaten_count).toBe(1);
     }
@@ -457,8 +480,6 @@ const tests = [
       ['win_8', 50, ''],
     ],
     tests: async (playAttemptDocs: PlayAttempt[], statDocs: Stat[], lvl: Level) => {
-      console.log(playAttemptDocs);
-
       expect(lvl.calc_playattempts_just_beaten_count).toBe(1);
       expect(lvl.calc_playattempts_duration_sum).toBe(50);
 

--- a/tests/pages/api/play-attempt/play-attempt.test.ts
+++ b/tests/pages/api/play-attempt/play-attempt.test.ts
@@ -14,8 +14,8 @@ import PlayAttempt from '../../../../models/db/playAttempt';
 import Stat from '../../../../models/db/stat';
 import { LevelModel, PlayAttemptModel, RecordModel, StatModel, UserModel } from '../../../../models/mongoose';
 import { AttemptContext } from '../../../../models/schemas/playAttemptSchema';
-import { processQueueMessages, queueCalcPlayAttempts } from '../../../../pages/api/internal-jobs/worker';
-import handler, { forceCompleteLatestPlayAttempt, getLastLevelPlayed } from '../../../../pages/api/play-attempt/index';
+import { processQueueMessages, queueCalcPlayAttempts, queueRefreshIndexCalcs } from '../../../../pages/api/internal-jobs/worker';
+import handler, { getLastLevelPlayed } from '../../../../pages/api/play-attempt/index';
 import statsHandler from '../../../../pages/api/stats/index';
 
 beforeAll(async () => {
@@ -39,15 +39,22 @@ interface PlayAttemptTest {
   tests: (playAttemptDocs: PlayAttempt[], statDocs: Stat[], lvl: Level) => Promise<void>;
 }
 
+/**
+ * notes:
+ * - LEVEL and LEVEL_4 are used in these tests
+ * - both start with a leastMoves of 20
+ * - USER created LEVEL, USER_B created LEVEL_4
+ */
+
 const tests = [
   {
     levelId: TestId.LEVEL_4,
     name: 'play at 5 min for 4 min',
     list: [
-      ['play', 5, 'created'],
-      ['play', 6, 'updated'],
-      ['play', 7, 'updated'],
-      ['play', 9, 'updated'],
+      ['play', 5 * MINUTE, 'created'],
+      ['play', 6 * MINUTE, 'updated'],
+      ['play', 7 * MINUTE, 'updated'],
+      ['play', 9 * MINUTE, 'updated'],
     ],
     tests: async (playAttemptDocs: PlayAttempt[], statDocs: Stat[], lvl: Level) => {
       expect(lvl.calc_playattempts_duration_sum).toBe(4 * MINUTE);
@@ -63,8 +70,8 @@ const tests = [
     name: 'play regular',
     list: [
       ['play', 0, 'created'],
-      ['play', 2, 'updated'],
-      ['play', 34, 'created'],
+      ['play', 2 * MINUTE, 'updated'],
+      ['play', 34 * MINUTE, 'created'],
     ],
     tests: async (playAttemptDocs: PlayAttempt[], statDocs: Stat[], lvl: Level) => {
       expect(lvl.calc_playattempts_duration_sum).toBe(2 * MINUTE);
@@ -93,10 +100,10 @@ const tests = [
     levelId: TestId.LEVEL_4,
     name: 'play at 14m for 3m, come back 1m later and then play for 3m',
     list: [
-      ['play', 14, 'created'],
-      ['play', 15, 'updated'],
-      ['play', 16, 'updated'],
-      ['play', 17, 'updated'],
+      ['play', 14 * MINUTE, 'created'],
+      ['play', 15 * MINUTE, 'updated'],
+      ['play', 16 * MINUTE, 'updated'],
+      ['play', 17 * MINUTE, 'updated'],
     ],
     tests: async (playAttemptDocs: PlayAttempt[], statDocs: Stat[], lvl: Level) => {
       expect(playAttemptDocs.length).toBe(1);
@@ -112,22 +119,26 @@ const tests = [
     name: 'play. dont win. come back and play. win. play a bit. leave. then come back and play',
     list: [
       ['play', 0, 'created'],
-      ['play', 1, 'updated'],
-      ['play', 2, 'updated'], // total = 2
-      ['play', 22, 'created'],
-      ['play', 23, 'updated'],
-      ['i_make_record', 24, 'ok'], // total = (0-2)+(24-22) = 4
-      ['play', 25, 'created'],
-      ['play', 26, 'updated'],
-      ['play', 50, 'created'],
-      ['play', 51, 'updated'],
-      ['play', 52, 'updated'],
+      ['play', 1 * MINUTE, 'updated'],
+      ['play', 2 * MINUTE, 'updated'], // total = 2
+      ['play', 22 * MINUTE, 'created'],
+      ['play', 23 * MINUTE, 'updated'],
+      ['win_10', 24 * MINUTE, 'ok'], // total = 2 + (24-22) = 4
+      ['play', 25 * MINUTE, 'created'],
+      ['play', 26 * MINUTE, 'updated'],
+      ['play', 27 * MINUTE, 'updated'],
+      ['win_8', 28 * MINUTE, 'ok'], // total = 4 + (28-25) = 7
+      ['play', 29 * MINUTE, 'created'],
+      ['play', 30 * MINUTE, 'updated'],
+      ['play', 50 * MINUTE, 'created'],
+      ['play', 51 * MINUTE, 'updated'],
+      ['play', 52 * MINUTE, 'updated'],
     ],
     tests: async (playAttemptDocs: PlayAttempt[], statDocs: Stat[], lvl: Level) => {
       expect(lvl.calc_playattempts_just_beaten_count).toBe(1);
-      expect(lvl.calc_playattempts_duration_sum).toBe(4 * MINUTE);
+      expect(lvl.calc_playattempts_duration_sum).toBe(7 * MINUTE);
 
-      expect(playAttemptDocs.length).toBe(4);
+      expect(playAttemptDocs.length).toBe(5);
       expect(playAttemptDocs[0].updateCount).toBe(2);
       expect(playAttemptDocs[0].attemptContext).toBe(AttemptContext.BEATEN);
       expect(playAttemptDocs[1].updateCount).toBe(1);
@@ -136,6 +147,8 @@ const tests = [
       expect(playAttemptDocs[2].attemptContext).toBe(AttemptContext.JUST_BEATEN);
       expect(playAttemptDocs[3].updateCount).toBe(2);
       expect(playAttemptDocs[3].attemptContext).toBe(AttemptContext.UNBEATEN);
+      expect(playAttemptDocs[4].updateCount).toBe(2);
+      expect(playAttemptDocs[4].attemptContext).toBe(AttemptContext.UNBEATEN);
       expect(lvl.calc_playattempts_unique_users).toStrictEqual([new Types.ObjectId(TestId.USER)]);
       expect(lvl.calc_playattempts_just_beaten_count).toBe(1);
     }
@@ -145,9 +158,9 @@ const tests = [
     name: 'win right away then return 25 minutes later for a moment',
     list: [
       ['play', 0, 'created'],
-      ['play', 1, 'updated'],
-      ['i_make_record', 1, ''],
-      ['play', 25, 'created'],
+      ['play', 1 * MINUTE, 'updated'],
+      ['win_8', 1 * MINUTE, ''],
+      ['play', 25 * MINUTE, 'created'],
     ],
     tests: async (playAttemptDocs: PlayAttempt[], statDocs: Stat[], lvl: Level) => {
       expect(lvl.calc_playattempts_duration_sum).toBe(1 * MINUTE );
@@ -156,7 +169,7 @@ const tests = [
       expect(playAttemptDocs[0].attemptContext).toBe(AttemptContext.BEATEN);
       expect(playAttemptDocs[0].updateCount).toBe(0);
       expect(playAttemptDocs[1].attemptContext).toBe(AttemptContext.JUST_BEATEN);
-      expect(playAttemptDocs[1].updateCount).toBe(3);
+      expect(playAttemptDocs[1].updateCount).toBe(2);
     }
   },
   {
@@ -164,12 +177,12 @@ const tests = [
     name: 'win right away then continue to play',
     list: [
       ['play', 0, 'created'],
-      ['play', 1, 'updated'], // sum = 1
-      ['i_make_record', 2, 'ok'], // sum = 1+1 = 2
-      ['play', 3, 'created'],
-      ['play', 4, 'updated'],
-      ['play', 20, 'created'],
-      ['play', 21, 'updated'],
+      ['play', 1 * MINUTE, 'updated'], // sum = 1
+      ['win_8', 2 * MINUTE, 'ok'], // sum = 1+1 = 2
+      ['play', 3 * MINUTE, 'created'],
+      ['play', 4 * MINUTE, 'updated'],
+      ['play', 20 * MINUTE, 'created'],
+      ['play', 21 * MINUTE, 'updated'],
     ],
     tests: async (playAttemptDocs: PlayAttempt[], statDocs: Stat[], lvl: Level) => {
       expect(lvl.calc_playattempts_duration_sum).toBe(2 * MINUTE);
@@ -178,7 +191,7 @@ const tests = [
       expect(playAttemptDocs[0].attemptContext).toBe(AttemptContext.BEATEN);
       expect(playAttemptDocs[1].updateCount).toBe(1);
       expect(playAttemptDocs[1].attemptContext).toBe(AttemptContext.BEATEN);
-      expect(playAttemptDocs[2].updateCount).toBe(3);
+      expect(playAttemptDocs[2].updateCount).toBe(2);
       expect(playAttemptDocs[2].attemptContext).toBe(AttemptContext.JUST_BEATEN);
       expect(lvl.calc_playattempts_just_beaten_count).toBe(1);
     }
@@ -188,15 +201,15 @@ const tests = [
     name: 'win right away but then a record comes in way later',
     list: [
       ['play', 0, 'created'],
-      ['win_inefficient', 0.1, 'ok'],
-      ['other_makes_record', 100, ''],
+      ['win_10', 0.1 * MINUTE, 'ok'],
+      ['b_win_8', 100 * MINUTE, ''],
     ],
     tests: async (playAttemptDocs: PlayAttempt[], statDocs: Stat[], lvl: Level,) => {
       expect(playAttemptDocs.length).toBe(2);
-      expect(playAttemptDocs[0].updateCount).toBe(1);
+      expect(playAttemptDocs[0].updateCount).toBe(0);
       expect(playAttemptDocs[0].attemptContext).toBe(AttemptContext.JUST_BEATEN);
       expect(playAttemptDocs[0].userId._id.toString()).toBe(TestId.USER_B);
-      expect(playAttemptDocs[1].updateCount).toBe(2);
+      expect(playAttemptDocs[1].updateCount).toBe(1);
       expect(playAttemptDocs[1].attemptContext).toBe(AttemptContext.UNBEATEN);
       expect(playAttemptDocs[1].userId._id.toString()).toBe(TestId.USER);
       expect(lvl.calc_playattempts_unique_users).toStrictEqual([new Types.ObjectId(TestId.USER), new Types.ObjectId(TestId.USER_B)]);
@@ -208,17 +221,19 @@ const tests = [
     name: 'win right away but then a record comes in way later then you match the record',
     list: [
       ['play', 0, 'created'],
-      ['win_inefficient', 0.1, 'ok'],
-      ['other_makes_record', 1, ''],
-      ['play', 2, 'updated'],
-      ['i_make_record', 3, ''],
+      ['win_10', 0.1 * MINUTE, 'ok'],
+      ['b_win_8', 1 * MINUTE, ''],
+      ['play', 2 * MINUTE, 'updated'],
+      ['win_8', 3 * MINUTE, ''],
     ],
     tests: async (playAttemptDocs: PlayAttempt[], statDocs: Stat[], lvl: Level) => {
       expect(playAttemptDocs.length).toBe(2);
-      expect(playAttemptDocs[0].updateCount).toBe(1);
+      expect(playAttemptDocs[0].updateCount).toBe(0);
       expect(playAttemptDocs[0].attemptContext).toBe(AttemptContext.JUST_BEATEN);
-      expect(playAttemptDocs[1].updateCount).toBe(4);
+      expect(playAttemptDocs[0].userId.toString()).toBe(TestId.USER_B);
+      expect(playAttemptDocs[1].updateCount).toBe(3);
       expect(playAttemptDocs[1].attemptContext).toBe(AttemptContext.JUST_BEATEN);
+      expect(playAttemptDocs[1].userId.toString()).toBe(TestId.USER);
       expect(lvl.calc_playattempts_just_beaten_count).toBe(2);
     }
   },
@@ -227,25 +242,25 @@ const tests = [
     name: 'win right away, a record comes in way later, come back and play for a while, give up, then come back and play again and win, then come back a way later and then play',
     list: [
       ['play', 0, 'created'], //
-      ['play', 1, 'updated'], // sum =1
-      ['play', 2, 'updated'], // sum =2
-      ['play', 3, 'updated'], // sum =3
-      ['play', 4, 'updated'], // sum =4
-      ['play', 5, 'updated'], // sum =5
-      ['play', 35, 'created'], // sum += 0 since it's a new play with no play attempts before or after...
-      ['win_inefficient', 100, 'ok'], // 5+0
-      ['other_makes_record', 200, ''], // 5+0
-      ['play', 250, 'created'], // 5+0
-      ['play', 251, 'updated'], // 5+1  = 6
-      ['play', 252, 'updated'], // sum+=256-250 = 6. Sum should now be +1 = 7
-      ['play', 253, 'updated'], // sum+=256-250 = 6. Sum should now be +1 = 8
-      ['play', 254, 'updated'], // sum+=256-250 = 6. Sum should now be +1 = 9
-      ['play', 255, 'updated'], // sum+=256-250 = 6. Sum should now be +1 = 10
-      ['play', 256, 'updated'], // sum+=256-250 = 6. Sum should now be +1 = 11
-      ['play', 300, 'created'],
-      ['play', 302, 'updated'],
-      ['i_make_record', 302.5, ''], //// sum+=(302.5-300) = 2.5. Sum should now be 11+2.5 = 13.5!
-      ['play', 345, 'created'],
+      ['play', 1 * MINUTE, 'updated'], // sum =1
+      ['play', 2 * MINUTE, 'updated'], // sum =2
+      ['play', 3 * MINUTE, 'updated'], // sum =3
+      ['play', 4 * MINUTE, 'updated'], // sum =4
+      ['play', 5 * MINUTE, 'updated'], // sum =5
+      ['play', 35 * MINUTE, 'created'], // sum += 0 since it's a new play with no play attempts before or after...
+      ['win_10', 100 * MINUTE, 'ok'], // 5+0
+      ['b_win_8', 200 * MINUTE, ''], // 5+0
+      ['play', 250 * MINUTE, 'created'], // 5+0
+      ['play', 251 * MINUTE, 'updated'], // 5+1  = 6
+      ['play', 252 * MINUTE, 'updated'], // sum+=256-250 = 6. Sum should now be +1 = 7
+      ['play', 253 * MINUTE, 'updated'], // sum+=256-250 = 6. Sum should now be +1 = 8
+      ['play', 254 * MINUTE, 'updated'], // sum+=256-250 = 6. Sum should now be +1 = 9
+      ['play', 255 * MINUTE, 'updated'], // sum+=256-250 = 6. Sum should now be +1 = 10
+      ['play', 256 * MINUTE, 'updated'], // sum+=256-250 = 6. Sum should now be +1 = 11
+      ['play', 300 * MINUTE, 'created'],
+      ['play', 302 * MINUTE, 'updated'],
+      ['win_8', 302.5 * MINUTE, ''], //// sum+=(302.5-300) = 2.5. Sum should now be 11+2.5 = 13.5!
+      ['play', 345 * MINUTE, 'created'],
     ],
     tests: async (playAttemptDocs: PlayAttempt[], statDocs: Stat[], lvl: Level) => {
       expect(playAttemptDocs.length).toBe(7);
@@ -288,7 +303,7 @@ const tests = [
     levelId: TestId.LEVEL_4,
     name: 'win right away but never send a playattempt (unlikely but possible)',
     list: [
-      ['win_inefficient', 0.1, 'ok'],
+      ['win_10', 6, 'ok'],
     ],
     tests: async (playAttemptDocs: PlayAttempt[], statDocs: Stat[], lvl: Level) => {
       expect(playAttemptDocs.length).toBe(1);
@@ -303,8 +318,8 @@ const tests = [
     levelId: TestId.LEVEL_4,
     name: 'win immediately then check last level played (can occur on 1 step levels)',
     list: [
-      ['win_inefficient', 1, 'ok'],
-      ['play', 1, 'created'],
+      ['win_10', 1 * MINUTE, 'ok'],
+      ['play', 1 * MINUTE, 'created'],
     ],
     tests: async (playAttemptDocs: PlayAttempt[], statDocs: Stat[], lvl: Level) => {
       expect(playAttemptDocs.length).toBe(2);
@@ -328,7 +343,7 @@ const tests = [
     name: 'dont win, come back 1 hour later and win without sending playattempt (rare but has happened)',
     list: [
       ['play', 0, 'created'],
-      ['i_make_record', 60, 'created']
+      ['win_8', 60 * MINUTE, 'created']
     ],
     tests: async (playAttemptDocs: PlayAttempt[], statDocs: Stat[], lvl: Level) => {
       expect(playAttemptDocs[0].attemptContext).toBe(AttemptContext.JUST_BEATEN);
@@ -336,7 +351,7 @@ const tests = [
 
       expect(playAttemptDocs[0].startTime).toBe(3600);
       expect(playAttemptDocs[0].endTime).toBe(3600);
-      expect(playAttemptDocs[0].updateCount).toBe(1);
+      expect(playAttemptDocs[0].updateCount).toBe(0);
 
       expect(playAttemptDocs[1].startTime).toBe(0);
       expect(playAttemptDocs[1].endTime).toBe(0);
@@ -349,11 +364,11 @@ const tests = [
     levelId: TestId.LEVEL,
     name: 'play own level',
     list: [
-      ['play', 1, 'created'],
-      ['play', 2, 'updated'],
-      ['play', 3, 'updated'],
-      ['play', 22, 'created'],
-      ['play', 23, 'updated'],
+      ['play', 1 * MINUTE, 'created'],
+      ['play', 2 * MINUTE, 'updated'],
+      ['play', 3 * MINUTE, 'updated'],
+      ['play', 22 * MINUTE, 'created'],
+      ['play', 23 * MINUTE, 'updated'],
     ],
     tests: async (playAttemptDocs: PlayAttempt[], statDocs: Stat[], lvl: Level) => {
       expect(lvl.calc_playattempts_just_beaten_count).toBe(0);
@@ -371,14 +386,14 @@ const tests = [
     levelId: TestId.LEVEL,
     name: 'set a record on own level after a while',
     list: [
-      ['play', 1, 'created'],
-      ['play', 2, 'updated'],
-      ['play', 3, 'updated'],
-      ['play', 22, 'created'],
-      ['play', 23, 'updated'],
-      ['i_make_record', 24, 'ok'],
-      ['play', 25, 'created'],
-      ['play', 26, 'updated'],
+      ['play', 1 * MINUTE, 'created'],
+      ['play', 2 * MINUTE, 'updated'],
+      ['play', 3 * MINUTE, 'updated'],
+      ['play', 22 * MINUTE, 'created'],
+      ['play', 23 * MINUTE, 'updated'],
+      ['win_8', 24 * MINUTE, 'ok'],
+      ['play', 25 * MINUTE, 'created'],
+      ['play', 26 * MINUTE, 'updated'],
     ],
     tests: async (playAttemptDocs: PlayAttempt[], statDocs: Stat[], lvl: Level) => {
       expect(lvl.calc_playattempts_just_beaten_count).toBe(1);
@@ -387,10 +402,69 @@ const tests = [
       expect(playAttemptDocs.length).toBe(3);
       expect(playAttemptDocs[0].updateCount).toBe(1);
       expect(playAttemptDocs[0].attemptContext).toBe(AttemptContext.BEATEN);
-      expect(playAttemptDocs[1].updateCount).toBe(3);
+      expect(playAttemptDocs[1].updateCount).toBe(2);
       expect(playAttemptDocs[1].attemptContext).toBe(AttemptContext.JUST_BEATEN);
       expect(playAttemptDocs[2].updateCount).toBe(2);
       expect(playAttemptDocs[2].attemptContext).toBe(AttemptContext.UNBEATEN);
+      expect(lvl.calc_playattempts_unique_users).toStrictEqual([new Types.ObjectId(TestId.USER)]);
+      expect(lvl.calc_playattempts_just_beaten_count).toBe(1);
+    }
+  },
+  {
+    levelId: TestId.LEVEL_4,
+    name: 'CarlAndre bug',
+    list: [
+      ['play', 0, 'created'],
+      ['play', 15, 'updated'],
+      ['play', 30, 'updated'],
+      ['win_20', 30, ''],
+      ['play', 41, 'created'],
+      ['play', 45, 'updated'],
+      ['play', 56, 'updated'],
+      ['play', 71, 'updated'],
+      ['play', 86, 'updated'],
+      ['win_10', 89, ''],
+      ['play', 103, 'created'],
+      ['play', 109, 'updated'],
+      ['play', 120, 'updated'],
+      ['win_8', 125, ''],
+    ],
+    tests: async (playAttemptDocs: PlayAttempt[], statDocs: Stat[], lvl: Level) => {
+      expect(lvl.calc_playattempts_just_beaten_count).toBe(1);
+      // 0-30, 41-89, 103-125
+      expect(lvl.calc_playattempts_duration_sum).toBe(100);
+
+      expect(playAttemptDocs.length).toBe(3);
+      expect(playAttemptDocs[0].updateCount).toBe(3);
+      expect(playAttemptDocs[0].attemptContext).toBe(AttemptContext.JUST_BEATEN);
+      expect(playAttemptDocs[1].updateCount).toBe(5);
+      expect(playAttemptDocs[1].attemptContext).toBe(AttemptContext.UNBEATEN);
+      expect(playAttemptDocs[2].updateCount).toBe(3);
+      expect(playAttemptDocs[2].attemptContext).toBe(AttemptContext.UNBEATEN);
+      expect(lvl.calc_playattempts_unique_users).toStrictEqual([new Types.ObjectId(TestId.USER)]);
+      expect(lvl.calc_playattempts_just_beaten_count).toBe(1);
+    }
+  },
+  {
+    levelId: TestId.LEVEL_4,
+    name: 'records with no breaks',
+    list: [
+      ['play', 0, 'created'],
+      ['play', 15, 'updated'],
+      ['play', 30, 'updated'],
+      ['win_20', 30, ''],
+      ['win_10', 40, ''],
+      ['win_8', 50, ''],
+    ],
+    tests: async (playAttemptDocs: PlayAttempt[], statDocs: Stat[], lvl: Level) => {
+      console.log(playAttemptDocs);
+
+      expect(lvl.calc_playattempts_just_beaten_count).toBe(1);
+      expect(lvl.calc_playattempts_duration_sum).toBe(50);
+
+      expect(playAttemptDocs.length).toBe(1);
+      expect(playAttemptDocs[0].updateCount).toBe(5);
+      expect(playAttemptDocs[0].attemptContext).toBe(AttemptContext.JUST_BEATEN);
       expect(lvl.calc_playattempts_unique_users).toStrictEqual([new Types.ObjectId(TestId.USER)]);
       expect(lvl.calc_playattempts_just_beaten_count).toBe(1);
     }
@@ -401,8 +475,8 @@ describe('Testing stats api', () => {
   for (const t of tests) {
     for (const [action, timestamp, expected] of t.list) {
       // delete all playattempts
-      test(t.name + ' action [' + action + '] at [t=' + timestamp + 'm]', async () => {
-        jest.spyOn(TimerUtil, 'getTs').mockReturnValue(timestamp as number * MINUTE);
+      test(t.name + ' action [' + action + '] at [t=' + timestamp + 's]', async () => {
+        jest.spyOn(TimerUtil, 'getTs').mockReturnValue(timestamp as number);
 
         if (action === 'play') {
           await testApiHandler({
@@ -430,7 +504,54 @@ describe('Testing stats api', () => {
               expect(response.message).toBe(expected);
             },
           });
-        } else if (action === 'win_inefficient') {
+        } else if (action === 'win_20') {
+          await testApiHandler({
+            handler: async (_, res) => {
+              const req: NextApiRequestWithAuth = {
+                method: 'PUT',
+                cookies: {
+                  token: getTokenCookieValue(TestId.USER),
+                },
+                body: {
+                  levelId: t.levelId,
+                  codes: [
+                    'ArrowRight',
+                    'ArrowRight',
+                    'ArrowRight',
+                    'ArrowRight',
+                    'ArrowDown',
+                    'ArrowDown',
+                    'ArrowDown',
+                    'ArrowUp',
+                    'ArrowDown',
+                    'ArrowUp',
+                    'ArrowDown',
+                    'ArrowUp',
+                    'ArrowDown',
+                    'ArrowUp',
+                    'ArrowDown',
+                    'ArrowUp',
+                    'ArrowDown',
+                    'ArrowUp',
+                    'ArrowDown',
+                    'ArrowDown',
+                  ],
+                },
+                headers: {
+                  'content-type': 'application/json',
+                },
+              } as unknown as NextApiRequestWithAuth;
+
+              await statsHandler(req, res);
+            },
+            test: async ({ fetch }) => {
+              const res = await fetch();
+              const response = await res.json();
+
+              expect(response.error).toBeUndefined();
+            },
+          });
+        } else if (action === 'win_10') {
           await testApiHandler({
             handler: async (_, res) => {
               const req: NextApiRequestWithAuth = {
@@ -467,8 +588,8 @@ describe('Testing stats api', () => {
               expect(response.error).toBeUndefined();
             },
           });
-        } else if (action === 'i_make_record' || action === 'other_makes_record') {
-          const usrId = action === 'i_make_record' ? TestId.USER : TestId.USER_B;
+        } else if (action === 'win_8' || action === 'b_win_8') {
+          const usrId = action === 'win_8' ? TestId.USER : TestId.USER_B;
 
           await testApiHandler({
             handler: async (_, res) => {
@@ -509,16 +630,23 @@ describe('Testing stats api', () => {
     }
 
     test(t.name + ' clear', async () => {
+      // NB: need to process here as there may be remaining queue messages (eg api/stats queueRefreshIndexCalcs)
+      await processQueueMessages();
+
       const allAttempts = await PlayAttemptModel.find({ levelId: t.levelId }, {}, { sort: { _id: -1 } });
       const allStats = await StatModel.find({ levelId: t.levelId }, {}, { sort: { ts: 1 } });
-      const lvlBeforeResync = await LevelModel.findByIdAndUpdate(t.levelId,
-        { $set: {
-          // NB: LEVEL and LEVEL_4 both have leastMoves of 20 so this works
-          leastMoves: 20
-        } }, { new: true });
+      // NB: LEVEL and LEVEL_4 both have leastMoves of 20 so this works
+      const lvlBeforeResync = await LevelModel.findByIdAndUpdate(t.levelId, { $set: { leastMoves: 20 } }, { new: true });
 
       await t.tests(allAttempts, allStats, lvlBeforeResync);
-      const resetArr = { $set: { calc_playattempts_just_beaten_count: 0, calc_difficulty_estimate: -1, calc_playattempts_duration_sum: 0, calc_playattempts_unique_users: [] } };
+
+      const resetArr = { $set: {
+        calc_difficulty_estimate: -1,
+        calc_playattempts_duration_sum: 0,
+        calc_playattempts_just_beaten_count: 0,
+        calc_playattempts_unique_users: [],
+        calc_stats_players_beaten: 0,
+      } };
       const resetLvl = await LevelModel.findOneAndUpdate({ _id: t.levelId }, resetArr, { new: true });
 
       expect(resetLvl).toBeDefined();
@@ -526,7 +654,11 @@ describe('Testing stats api', () => {
       expect(resetLvl.calc_playattempts_duration_sum).toBe(0);
       expect(resetLvl.calc_playattempts_unique_users.length).toBe(0);
       expect(resetLvl.calc_stats_players_beaten).toBe(0);
+      expect(resetLvl.calc_difficulty_estimate).toBe(-1);
+
+      // verify queue functions update level calc fields correctly
       await queueCalcPlayAttempts(lvlBeforeResync._id);
+      await queueRefreshIndexCalcs(lvlBeforeResync._id);
       await processQueueMessages();
       const lvlAfterResync = await LevelModel.findById(t.levelId);
 
@@ -535,7 +667,8 @@ describe('Testing stats api', () => {
       expect(lvlAfterResync.calc_difficulty_estimate).toBe(lvlBeforeResync.calc_difficulty_estimate);
       expect(lvlAfterResync.calc_stats_players_beaten.length).toBe(lvlBeforeResync.calc_stats_players_beaten.length);
       expect(lvlAfterResync.calc_playattempts_unique_users.sort()).toStrictEqual(lvlBeforeResync.calc_playattempts_unique_users.sort());
-      // Cleanup
+
+      // cleanup
       await PlayAttemptModel.deleteMany({ levelId: t.levelId });
       await StatModel.deleteMany({ levelId: t.levelId });
       await RecordModel.deleteMany({ levelId: t.levelId });
@@ -755,7 +888,52 @@ describe('Testing stats api', () => {
     expect(levelUpdated3?.calc_playattempts_just_beaten_count).toBe(5);
     expect(levelUpdated3?.calc_playattempts_unique_users?.length).toBe(10);
 
-    await forceCompleteLatestPlayAttempt(unbeatenUserId.toString(), level._id.toString(), 40, {});
+    jest.spyOn(TimerUtil, 'getTs').mockReturnValue(40);
+    await testApiHandler({
+      handler: async (_, res) => {
+        const req: NextApiRequestWithAuth = {
+          method: 'PUT',
+          cookies: {
+            token: getTokenCookieValue(unbeatenUserId.toString()),
+          },
+          body: {
+            levelId: level._id,
+            codes: [
+              'ArrowRight',
+              'ArrowRight',
+              'ArrowRight',
+              'ArrowRight',
+              'ArrowDown',
+              'ArrowUp',
+              'ArrowDown',
+              'ArrowUp',
+              'ArrowDown',
+              'ArrowUp',
+              'ArrowDown',
+              'ArrowUp',
+              'ArrowDown',
+              'ArrowUp',
+              'ArrowDown',
+              'ArrowUp',
+              'ArrowDown',
+              'ArrowDown',
+              'ArrowDown',
+              'ArrowDown',
+            ],
+          },
+          headers: {
+            'content-type': 'application/json',
+          },
+        } as unknown as NextApiRequestWithAuth;
+
+        await statsHandler(req, res);
+      },
+      test: async ({ fetch }) => {
+        const res = await fetch();
+
+        expect(res.status).toBe(200);
+      },
+    });
 
     const levelUpdated4 = await LevelModel.findById<Level>(level._id);
 
@@ -874,7 +1052,7 @@ describe('Testing stats api', () => {
   });
   test('POST with transaction error', async () => {
     jest.spyOn(logger, 'error').mockImplementation(() => ({} as Logger));
-    jest.spyOn(PlayAttemptModel, 'findOneAndUpdate').mockImplementationOnce(() => {
+    jest.spyOn(PlayAttemptModel, 'findOne').mockImplementationOnce(() => {
       throw new Error('Test error');
     });
     await testApiHandler({
@@ -903,7 +1081,7 @@ describe('Testing stats api', () => {
       },
     });
   });
-  test('POST with transaction error', async () => {
+  test('playAttempts should not sort by _id', async () => {
     const playAttemptId1 = new Types.ObjectId();
     const playAttempt1 = {
       _id: playAttemptId1,

--- a/tests/pages/api/stats/stats.test.ts
+++ b/tests/pages/api/stats/stats.test.ts
@@ -347,8 +347,8 @@ describe('Testing stats api', () => {
         const res = await fetch();
         const response = await res.json();
 
-        expect(response.error).toBe(`Error finding level ${TestId.LEVEL}`);
-        expect(res.status).toBe(404);
+        expect(response.error).toBe(`Unauthorized access for level ${TestId.LEVEL}`);
+        expect(res.status).toBe(401);
         const u = await UserModel.findById(TestId.USER);
 
         expect(u.calc_records).toEqual(2);
@@ -554,11 +554,8 @@ describe('Testing stats api', () => {
     // The findOne that api/stats checks for a stat existing already, let's make this fail by returning a promise that errors
 
     jest.spyOn(logger, 'error').mockImplementation(() => ({} as Logger));
+    jest.spyOn(StatModel, 'updateOne').mockRejectedValueOnce(new Error('Test DB error'));
 
-    jest.spyOn(StatModel, 'updateOne').mockReturnValueOnce({
-      exec: () => {throw new Error('Test DB error');}
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } as any);
     await testApiHandler({
       handler: async (_, res) => {
         const req: NextApiRequestWithAuth = {


### PR DESCRIPTION
Fixes #947 

- using `string` instead of `Types.ObjectId` caused a bug in `forceCompleteLatestPlayAttempt`
- `api/play-attempt` extended the most recent non-`JUST_BEATEN` play attempt, which caused the following bug:
  - playattempt A `UNBEATEN` from 0-10
  - playattempt B `JUST_BEATEN` from 10-20
  - playattempt API extends A and overlaps B, resulting in inaccurate times
- refactored `api/play-attempt` and `api/stats` to be more efficient on average
- added more play attempt tests

After deploying we need to:
- run a script to sanitize playattempt data and remove overlaps
- run save.ts on all levels