### PR TITLE
disallow list for notifications

### DIFF
--- a/components/settings/settingsNotifications.tsx
+++ b/components/settings/settingsNotifications.tsx
@@ -72,12 +72,20 @@ export default function SettingsNotifications() {
     [NotificationType.UPGRADED_TO_PRO]: 'Upgraded to Pro',
   };
 
-  const emailNotifs = userConfig?.emailNotificationsList || [];
-  const pushNotifs = userConfig?.pushNotificationsList || [];
-  // Create a formatted list of all notification types with two checkboxes... one for email and one for mobile push notifications.
+  let disallowedEmailNotifications = allNotifs.filter(notif => !userConfig?.emailNotificationsList?.includes(notif));
+  let disallowedPushNotifications = allNotifs.filter(notif => !userConfig?.pushNotificationsList?.includes(notif));
 
+  if (userConfig?.disallowedEmailNotifications !== undefined) {
+    disallowedEmailNotifications = userConfig.disallowedEmailNotifications;
+  }
+
+  if (userConfig?.disallowedPushNotifications !== undefined) {
+    disallowedPushNotifications = userConfig.disallowedPushNotifications;
+  }
+
+  // Create a formatted list of all notification types with two checkboxes... one for email and one for mobile push notifications.
   const updateNotifs = (notif: NotificationType, type: 'email' | 'push') => {
-    const notifList = type === 'email' ? emailNotifs : pushNotifs;
+    const notifList = type === 'email' ? disallowedEmailNotifications : disallowedPushNotifications;
     const notifIndex = notifList.indexOf(notif);
 
     if (notifIndex === -1) {
@@ -88,8 +96,8 @@ export default function SettingsNotifications() {
 
     updateUserConfig(
       JSON.stringify({
-        emailNotificationsList: emailNotifs,
-        pushNotificationsList: pushNotifs,
+        disallowedEmailNotifications: disallowedEmailNotifications,
+        disallowedPushNotifications: disallowedPushNotifications,
       }),
       'notification settings',
     );
@@ -107,22 +115,21 @@ export default function SettingsNotifications() {
                   Email
                 </label>
                 <input
-                  checked={emailNotifs.length === allNotifs.length}
+                  checked={disallowedEmailNotifications.length === 0}
                   id='toggleAllEmailNotifs'
                   name='toggleAllEmailNotifs'
-
                   onChange={() => {
-                    if (emailNotifs.length === allNotifs.length) {
+                    if (disallowedEmailNotifications.length !== 0) {
                       updateUserConfig(
                         JSON.stringify({
-                          emailNotificationsList: [],
+                          disallowedEmailNotifications: [],
                         }),
                         'notification settings',
                       );
                     } else {
                       updateUserConfig(
                         JSON.stringify({
-                          emailNotificationsList: allNotifs,
+                          disallowedEmailNotifications: allNotifs,
                         }),
                         'notification settings',
                       );
@@ -138,21 +145,21 @@ export default function SettingsNotifications() {
                   Push
                 </label>
                 <input
-                  checked={pushNotifs.length === allNotifs.length}
+                  checked={disallowedPushNotifications.length === 0}
                   id='toggleAllPushNotifs'
                   name='toggleAllPushNotifs'
                   onChange={() => {
-                    if (pushNotifs.length === allNotifs.length) {
+                    if (disallowedPushNotifications.length !== 0) {
                       updateUserConfig(
                         JSON.stringify({
-                          pushNotificationsList: [],
+                          disallowedPushNotifications: [],
                         }),
                         'notification settings',
                       );
                     } else {
                       updateUserConfig(
                         JSON.stringify({
-                          pushNotificationsList: allNotifs,
+                          disallowedPushNotifications: allNotifs,
                         }),
                         'notification settings',
                       );
@@ -177,7 +184,7 @@ export default function SettingsNotifications() {
                 </td>
                 <td className='px-4 py-2 text-center'>
                   <input
-                    checked={emailNotifs.includes(notif)}
+                    checked={!disallowedEmailNotifications.includes(notif)}
                     id={notif + '-email'}
                     name={notif}
                     onChange={() => updateNotifs(notif, 'email')}
@@ -186,7 +193,7 @@ export default function SettingsNotifications() {
                 </td>
                 <td className='px-4 py-2 text-center'>
                   <input
-                    checked={pushNotifs.includes(notif)}
+                    checked={!disallowedPushNotifications.includes(notif)}
                     id={notif + '-push'}
                     name={notif}
                     onChange={() => updateNotifs(notif, 'push')}

--- a/lib/initializeLocalDb.ts
+++ b/lib/initializeLocalDb.ts
@@ -1,11 +1,11 @@
 import { EmailDigestSettingTypes } from '@root/constants/emailDigest';
 import { AttemptContext } from '@root/models/schemas/playAttemptSchema';
 import { PASSWORD_SALTROUNDS } from '@root/models/schemas/userSchema';
+import { getNewUserConfig } from '@root/pages/api/user-config';
 import bcrypt from 'bcryptjs';
 import { Types } from 'mongoose';
 import Role from '../constants/role';
 import TestId from '../constants/testId';
-import Theme from '../constants/theme';
 import { generateCollectionSlug, generateLevelSlug } from '../helpers/generateSlug';
 import { TimerUtil } from '../helpers/getTs';
 import Collection from '../models/db/collection';
@@ -83,35 +83,12 @@ export default async function initializeLocalDb() {
   { ordered: false }
   ));
 
-  promises.push(UserConfigModel.insertMany(
-    [
-      {
-        _id: new Types.ObjectId(),
-        theme: Theme.Modern,
-        userId: new Types.ObjectId(TestId.USER),
-        emailConfirmed: true,
-      },
-      {
-        _id: new Types.ObjectId(),
-        theme: Theme.Modern,
-        userId: new Types.ObjectId(TestId.USER_B),
-        emailConfirmed: true,
-      },
-      {
-        _id: new Types.ObjectId(),
-        theme: Theme.Modern,
-        userId: new Types.ObjectId(TestId.USER_GUEST),
-        emailConfirmed: false,
-      },
-      {
-        _id: new Types.ObjectId(),
-        theme: Theme.Modern,
-        userId: new Types.ObjectId(TestId.USER_PRO),
-        emailConfirmed: true,
-        emailDigest: EmailDigestSettingTypes.NONE,
-      },
-    ], { ordered: false }
-  ));
+  promises.push(UserConfigModel.insertMany([
+    getNewUserConfig([], 0, new Types.ObjectId(TestId.USER), { emailConfirmed: true }),
+    getNewUserConfig([], 0, new Types.ObjectId(TestId.USER_B), { emailConfirmed: true }),
+    getNewUserConfig([Role.GUEST], 0, new Types.ObjectId(TestId.USER_GUEST)),
+    getNewUserConfig([Role.PRO], 0, new Types.ObjectId(TestId.USER_PRO), { emailConfirmed: true, emailDigest: EmailDigestSettingTypes.NONE }),
+  ], { ordered: false }));
 
   // LEVEL
   promises.push(LevelModel.insertMany(

--- a/models/db/userConfig.d.ts
+++ b/models/db/userConfig.d.ts
@@ -6,6 +6,8 @@ import User from './user';
 
 interface UserConfig {
   _id: Types.ObjectId;
+  disallowedEmailNotifications: NotificationType[];
+  disallowedPushNotifications: NotificationType[];
   emailConfirmationToken: string;
   emailConfirmed: boolean;
   emailDigest: EmailDigestSettingTypes;

--- a/models/schemas/userConfigSchema.ts
+++ b/models/schemas/userConfigSchema.ts
@@ -10,6 +10,16 @@ const UserConfigSchema = new mongoose.Schema<UserConfig>(
       type: mongoose.Schema.Types.ObjectId,
       required: true,
     },
+    disallowedEmailNotifications: {
+      type: [{ type: String, enum: NotificationType }],
+      required: false,
+      default: [],
+    },
+    disallowedPushNotifications: {
+      type: [{ type: String, enum: NotificationType }],
+      required: false,
+      default: [],
+    },
     emailConfirmationToken: {
       type: String,
       select: false,

--- a/pages/api/internal-jobs/worker/sendEmailNotification.ts
+++ b/pages/api/internal-jobs/worker/sendEmailNotification.ts
@@ -2,40 +2,40 @@ import getEmailBody from '@root/helpers/getEmailBody';
 import getMobileNotification from '@root/helpers/getMobileNotification';
 import Notification from '@root/models/db/notification';
 import User from '@root/models/db/user';
-import UserConfig from '@root/models/db/userConfig';
-import { EmailLogModel, UserConfigModel, UserModel } from '@root/models/mongoose';
+import { EmailLogModel, UserModel } from '@root/models/mongoose';
 import { Types } from 'mongoose';
 import { sendMail } from '../email-digest';
 
+/**
+ * Send an email notification
+ * NB: assumes the user's email notification settings have already been checked
+ */
 export async function sendEmailNotification(notification: Notification) {
-  const userConfig = await UserConfigModel.findOne({ userId: notification.userId }, { emailNotificationsList: 1 }).lean<UserConfig>();
-  const validTypes = userConfig?.emailNotificationsList || [];
-
-  if (validTypes.includes(notification.type)) {
-    const lastSent = await EmailLogModel.findOne({
-      userId: notification.userId,
-      type: notification.type,
-    }).sort({ createdAt: -1 });
-
-    const lastSentTime = lastSent ? new Date(lastSent.createdAt).getTime() : 0;
-    const lastLoggedInTimeQuery = await UserModel.findOne({ _id: notification.userId }, { last_visited_at: 1 }).lean<User>();
-    const lastLoggedInTime = lastLoggedInTimeQuery?.last_visited_at ? new Date(1000 * lastLoggedInTimeQuery.last_visited_at).getTime() : 0;
-
-    // check if it has been less than 24 hours since last email
-    if (Date.now() - lastSentTime < 1000 * 60 * 60 * 24) {
-    // query last time we sent an email to this user. if they have not logged in since, do not send another email
-      if (lastLoggedInTime < lastSentTime) {
-        return 'email not sent [lastLoggedInTime < lastSentTime]';
-      }
-    }
-
-    const mobileNotification = getMobileNotification(notification);
-    const emailBody = getEmailBody(null, 0, mobileNotification.title, notification.userId, mobileNotification.body, mobileNotification.url, 'View');
-
-    await sendMail(new Types.ObjectId(), notification.type, notification.userId, mobileNotification.title, emailBody);
-
-    return 'email sent';
+  if (process.env.NODE_ENV === 'test') {
+    return 'email notification not sent [test]';
   }
 
-  return 'email not sent (not enabled from user config)';
+  const lastSent = await EmailLogModel.findOne({
+    userId: notification.userId,
+    type: notification.type,
+  }).sort({ createdAt: -1 });
+
+  const lastSentTime = lastSent ? new Date(lastSent.createdAt).getTime() : 0;
+  const lastLoggedInTimeQuery = await UserModel.findOne({ _id: notification.userId }, { last_visited_at: 1 }).lean<User>();
+  const lastLoggedInTime = lastLoggedInTimeQuery?.last_visited_at ? new Date(1000 * lastLoggedInTimeQuery.last_visited_at).getTime() : 0;
+
+  // check if it has been less than 24 hours since last email
+  if (Date.now() - lastSentTime < 1000 * 60 * 60 * 24) {
+  // query last time we sent an email to this user. if they have not logged in since, do not send another email
+    if (lastLoggedInTime < lastSentTime) {
+      return 'email not sent [lastLoggedInTime < lastSentTime]';
+    }
+  }
+
+  const mobileNotification = getMobileNotification(notification);
+  const emailBody = getEmailBody(null, 0, mobileNotification.title, notification.userId, mobileNotification.body, mobileNotification.url, 'View');
+
+  await sendMail(new Types.ObjectId(), notification.type, notification.userId, mobileNotification.title, emailBody);
+
+  return 'email sent';
 }

--- a/pages/api/internal-jobs/worker/sendPushNotification.ts
+++ b/pages/api/internal-jobs/worker/sendPushNotification.ts
@@ -4,7 +4,15 @@ import Notification from '@root/models/db/notification';
 import { DeviceModel } from '@root/models/mongoose';
 import admin from 'firebase-admin';
 
+/**
+ * Send a mobile push notification
+ * NB: assumes the user's push notification settings have already been checked
+ */
 export async function sendPushNotification(notification: Notification) {
+  if (process.env.NODE_ENV === 'test') {
+    return 'push notification not sent [test]';
+  }
+
   if (!process.env.FIREBASE_CLIENT_EMAIL || !process.env.FIREBASE_PRIVATE_KEY || !process.env.FIREBASE_PROJECT_ID) {
     return 'push not sent. Firebase environment variables not set';
   }

--- a/pages/api/user-config/index.ts
+++ b/pages/api/user-config/index.ts
@@ -1,5 +1,10 @@
+import { EmailDigestSettingTypes } from '@root/constants/emailDigest';
+import NotificationType from '@root/constants/notificationType';
+import Role from '@root/constants/role';
+import getEmailConfirmationToken from '@root/helpers/getEmailConfirmationToken';
 import isGuest from '@root/helpers/isGuest';
 import { logger } from '@root/helpers/logger';
+import User from '@root/models/db/user';
 import UserConfig from '@root/models/db/userConfig';
 import { Types } from 'mongoose';
 import type { NextApiResponse } from 'next';
@@ -8,15 +13,34 @@ import { ValidArray, ValidNumber, ValidType } from '../../../helpers/apiWrapper'
 import withAuth, { NextApiRequestWithAuth } from '../../../lib/withAuth';
 import { UserConfigModel } from '../../../models/mongoose';
 
-export async function getUserConfig(userId: Types.ObjectId) {
-  let userConfig = await UserConfigModel.findOne({ userId: userId }, { '__v': 0 }).lean<UserConfig>();
+export function getNewUserConfig(roles: Role[], tutorialCompletedAt: number, userId: Types.ObjectId, params?: Partial<UserConfig>) {
+  let emailDigest = EmailDigestSettingTypes.DAILY;
+
+  if (roles.includes(Role.GUEST)) {
+    emailDigest = EmailDigestSettingTypes.NONE;
+  }
+
+  const emailConfirmationToken = getEmailConfirmationToken();
+
+  return {
+    _id: new Types.ObjectId(),
+    disallowedEmailNotifications: Object.values(NotificationType).filter((type) => type !== NotificationType.NEW_WALL_POST && type !== NotificationType.NEW_WALL_REPLY && type !== NotificationType.NEW_ACHIEVEMENT),
+    disallowedPushNotifications: [],
+    emailConfirmed: false,
+    emailConfirmationToken: emailConfirmationToken,
+    emailDigest: emailDigest,
+    theme: Theme.Modern,
+    tutorialCompletedAt: tutorialCompletedAt,
+    userId: userId,
+    ...params,
+  } as Partial<UserConfig>;
+}
+
+export async function getUserConfig(user: User) {
+  let userConfig = await UserConfigModel.findOne({ userId: user._id }, { '__v': 0 }).lean<UserConfig>();
 
   if (!userConfig) {
-    userConfig = await UserConfigModel.create({
-      _id: new Types.ObjectId(),
-      theme: Theme.Modern,
-      userId: userId,
-    });
+    userConfig = await UserConfigModel.create(getNewUserConfig(user.roles, 0, user._id));
   }
 
   return userConfig;
@@ -28,9 +52,9 @@ export default withAuth({
   PUT: {
     body: {
       deviceToken: ValidType('string', false),
+      disallowedEmailNotifications: ValidArray(false),
+      disallowedPushNotifications: ValidArray(false),
       emailDigest: ValidType('string', false),
-      emailNotificationsList: ValidArray(false),
-      pushNotificationsList: ValidArray(false),
       showPlayStats: ValidType('boolean', false),
       theme: ValidType('string', false),
       tutorialCompletedAt: ValidNumber(false),
@@ -39,15 +63,15 @@ export default withAuth({
   },
 }, async (req: NextApiRequestWithAuth, res: NextApiResponse) => {
   if (req.method === 'GET') {
-    const userConfig = await getUserConfig(req.user._id);
+    const userConfig = await getUserConfig(req.user);
 
     return res.status(200).json(userConfig);
   } else if (req.method === 'PUT') {
     const {
       deviceToken,
+      disallowedEmailNotifications,
+      disallowedPushNotifications,
       emailDigest,
-      emailNotificationsList,
-      pushNotificationsList,
       showPlayStats,
       theme,
       toursCompleted,
@@ -82,12 +106,12 @@ export default withAuth({
       setObj['toursCompleted'] = toursCompleted;
     }
 
-    if (emailNotificationsList) {
-      setObj['emailNotificationsList'] = emailNotificationsList;
+    if (disallowedEmailNotifications !== undefined) {
+      setObj['disallowedEmailNotifications'] = disallowedEmailNotifications;
     }
 
-    if (pushNotificationsList) {
-      setObj['pushNotificationsList'] = pushNotificationsList;
+    if (disallowedPushNotifications !== undefined) {
+      setObj['disallowedPushNotifications'] = disallowedPushNotifications;
     }
 
     // check if setObj is blank

--- a/pages/api/user/index.ts
+++ b/pages/api/user/index.ts
@@ -41,7 +41,7 @@ export default withAuth({
     const [enrichedUser, multiplayerProfile, userConfig] = await Promise.all([
       enrichReqUser(req.user),
       MultiplayerProfileModel.findOne({ 'userId': req.user._id }),
-      getUserConfig(req.user._id),
+      getUserConfig(req.user),
     ]);
 
     cleanUser(enrichedUser);

--- a/pages/settings/[[...tab]].tsx
+++ b/pages/settings/[[...tab]].tsx
@@ -85,7 +85,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   let userConfig: UserConfig | null = null;
 
   if (tab === SettingsTab.Account || tab === SettingsTab.Notifications) {
-    userConfig = await getUserConfig(reqUser._id);
+    userConfig = await getUserConfig(reqUser);
   }
 
   return {

--- a/tests/pages/api/signup/signup.test.ts
+++ b/tests/pages/api/signup/signup.test.ts
@@ -308,8 +308,8 @@ describe('pages/api/signup', () => {
         const config = await UserConfigModel.findOne({ userId: db._id }) as UserConfig;
 
         expect(config).toBeDefined();
-        expect(config.emailNotificationsList.sort()).toStrictEqual([NotificationType.NEW_ACHIEVEMENT, NotificationType.NEW_WALL_POST, NotificationType.NEW_WALL_REPLY]);
-        expect(config.pushNotificationsList.sort()).toStrictEqual(Object.values(NotificationType).sort());
+        expect(config.disallowedEmailNotifications.sort()).toStrictEqual(Object.values(NotificationType).filter((type) => type !== NotificationType.NEW_WALL_POST && type !== NotificationType.NEW_WALL_REPLY && type !== NotificationType.NEW_ACHIEVEMENT).sort());
+        expect(config.disallowedPushNotifications).toStrictEqual([]);
       },
     });
   });

--- a/tests/pages/api/user-config/notification-preferences.test.ts
+++ b/tests/pages/api/user-config/notification-preferences.test.ts
@@ -1,9 +1,7 @@
-import AchievementType from '@root/constants/achievements/achievementType';
 import NotificationType from '@root/constants/notificationType';
-import { createNewAchievement, createNewFollowerNotification, createNewReviewOnYourLevelNotification } from '@root/helpers/notificationHelper';
+import { createNewFollowerNotification, createNewReviewOnYourLevelNotification } from '@root/helpers/notificationHelper';
 import { processQueueMessages } from '@root/pages/api/internal-jobs/worker';
 import { enableFetchMocks } from 'jest-fetch-mock';
-import { Types } from 'mongoose';
 import { testApiHandler } from 'next-test-api-route-handler';
 import { EmailDigestSettingTypes } from '../../../../constants/emailDigest';
 import TestId from '../../../../constants/testId';
@@ -49,11 +47,8 @@ jest.mock('nodemailer', () => ({
 }));
 
 describe('account settings notification preferences', () => {
-  const emailNotificationList = Object.values(NotificationType);
-  const pushNotificationList = Object.values(NotificationType);
-
-  // remove new follower notification from only emails
-  emailNotificationList.splice(emailNotificationList.indexOf(NotificationType.NEW_FOLLOWER), 1);
+  const disallowedEmailNotifications = [] as NotificationType[];
+  const disallowedPushNotifications = [NotificationType.NEW_FOLLOWER];
 
   // enable all notifications
   test('enable all notifications except for new follower', async () => {
@@ -62,8 +57,8 @@ describe('account settings notification preferences', () => {
         const req: NextApiRequestWithAuth = {
           ...defaultObj,
           body: {
-            emailNotificationsList: emailNotificationList,
-            pushNotificationsList: pushNotificationList,
+            disallowedEmailNotifications: disallowedEmailNotifications,
+            disallowedPushNotifications: disallowedPushNotifications,
             emailDigestSetting: EmailDigestSettingTypes.DAILY,
           }
         } as unknown as NextApiRequestWithAuth;
@@ -80,11 +75,8 @@ describe('account settings notification preferences', () => {
         // check the db
         const config = await UserConfigModel.findOne({ userId: TestId.USER }).lean<UserConfig>() as UserConfig;
 
-        expect(config.pushNotificationsList).toEqual(pushNotificationList);
-        expect(config.emailNotificationsList).toEqual(emailNotificationList);
-        // make sure it does not have new follower
-        expect(config.emailNotificationsList).not.toContain(NotificationType.NEW_FOLLOWER);
-        expect(config.pushNotificationsList).toContain(NotificationType.NEW_FOLLOWER);
+        expect(config.disallowedEmailNotifications).toEqual(disallowedEmailNotifications);
+        expect(config.disallowedPushNotifications).toEqual(disallowedPushNotifications);
       },
     });
   });
@@ -125,8 +117,8 @@ describe('account settings notification preferences', () => {
     const queueProcessed = await processQueueMessages();
 
     expect(queueProcessed).toBe('Processed 2 messages with no errors');
-    expect(originalSendEmail.sendEmailNotification).toHaveBeenCalledTimes(0); // important
-    expect(originalSendPush.sendPushNotification).toHaveBeenCalledTimes(1); // important!
+    expect(originalSendEmail.sendEmailNotification).toHaveBeenCalledTimes(1); // important
+    expect(originalSendPush.sendPushNotification).toHaveBeenCalledTimes(0); // important!
   });
   test('create a new achievement notification', async () => {
     // spy on sendMailRefMock.ref
@@ -140,12 +132,12 @@ describe('account settings notification preferences', () => {
     originalSendPush.sendPushNotification = jest.fn().mockImplementation(() => {
       // do nothing
     });
-    await createNewAchievement(AchievementType.SOLVED_LEVELS_100, new Types.ObjectId(TestId.USER_GUEST), false );
+    await createNewFollowerNotification(TestId.USER_B, TestId.USER_GUEST);
 
     const queueProcessed = await processQueueMessages();
 
     expect(queueProcessed).toBe('Processed 2 messages with no errors');
     expect(originalSendEmail.sendEmailNotification).toHaveBeenCalledTimes(0); // important
-    expect(originalSendPush.sendPushNotification).toHaveBeenCalledTimes(0); // important!
+    expect(originalSendPush.sendPushNotification).toHaveBeenCalledTimes(1); // important!
   });
 });


### PR DESCRIPTION
change email/push notification settings to be a disallow list instead of allow list

now when we add new notification types they will automatically be turned on instead of never being turned on