### PR TITLE
Fix unpublish level modal button label

### DIFF
--- a/components/modal/createMatchModal.tsx
+++ b/components/modal/createMatchModal.tsx
@@ -39,6 +39,7 @@ export default function CreateMatchModal({ closeModal, isOpen, onConfirm }: Crea
 
         onConfirm(matchType, isPrivate, isRated);
       }}
+      confirmText={'Create Match'}
       title={'Create Match'}
     >
       <div className='flex flex-col gap-6'>

--- a/components/modal/index.tsx
+++ b/components/modal/index.tsx
@@ -124,7 +124,7 @@ export default function Modal({
                         className='group relative overflow-hidden bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white font-bold py-2 px-6 rounded-lg shadow-md transform hover:scale-105 transition-all duration-200'
                         disabled={disabled}
                         onClick={() => {}}
-                        text={confirmText || submitLabel || 'Create Match'}
+                        text={confirmText || submitLabel || 'Confirm'}
                         type='submit'
                       />
                       <ModalButton

--- a/components/modal/unpublishLevelModal.tsx
+++ b/components/modal/unpublishLevelModal.tsx
@@ -53,6 +53,7 @@ export default function UnpublishLevelModal({ closeModal, isOpen, level }: Unpub
       disabled={isUnpublishing}
       isOpen={isOpen}
       onConfirm={onConfirm}
+      confirmText={'Unpublish'}
       title={'Unpublish Level'}
     >
       <div className='break-words text-center'>


### PR DESCRIPTION
Fixes incorrect 'Create Match' button label in Unpublish Level modal by updating shared modal default and explicitly setting labels.

The shared `Modal` component had "Create Match" as its fallback `confirmText`. This caused modals that didn't explicitly set their `confirmText` (like the Unpublish Level modal) to display the wrong label. This PR changes the default to "Confirm" and ensures specific modals like "Create Match" and "Unpublish Level" set their own labels.

---
<a href="https://cursor.com/background-agent?bcId=bc-53b0edb4-06ff-4bac-8300-a397bff70d86">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-53b0edb4-06ff-4bac-8300-a397bff70d86">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

