### PR TITLE
Throttle multiplayer game state updates

### DIFF
--- a/server/socket/gameStateRateLimiter.ts
+++ b/server/socket/gameStateRateLimiter.ts
@@ -1,0 +1,47 @@
+import { logger } from '@root/helpers/logger';
+
+interface GameStateAttempt {
+  timestamps: number[];
+}
+
+// Rate limiting for match game state messages (2 per second)
+const gameStateAttempts = new Map<string, GameStateAttempt>();
+const MAX_MESSAGES_PER_WINDOW = 2; // 2 updates
+const WINDOW_DURATION_MS = 1000; // per 1 second
+const CLEANUP_INTERVAL_MS = 300000; // 5 minutes
+
+// Clean up old entries periodically
+setInterval(() => {
+  const now = Date.now();
+
+  for (const [key, data] of gameStateAttempts.entries()) {
+    // Remove timestamps older than window duration
+    data.timestamps = data.timestamps.filter(timestamp => now - timestamp < WINDOW_DURATION_MS);
+
+    // If no timestamps left, remove the entry
+    if (data.timestamps.length === 0) {
+      gameStateAttempts.delete(key);
+    }
+  }
+}, CLEANUP_INTERVAL_MS);
+
+export function isGameStateRateLimited(userId: string): boolean {
+  const now = Date.now();
+  const userAttempts = gameStateAttempts.get(userId) || { timestamps: [] };
+
+  // Remove old timestamps outside the window
+  userAttempts.timestamps = userAttempts.timestamps.filter(timestamp => now - timestamp < WINDOW_DURATION_MS);
+
+  // Check if user has exceeded the limit
+  if (userAttempts.timestamps.length >= MAX_MESSAGES_PER_WINDOW) {
+    logger.debug?.(`User ${userId} gameState rate limited: ${userAttempts.timestamps.length} in ${WINDOW_DURATION_MS}ms`);
+    return true;
+  }
+
+  // Add current timestamp and update the map
+  userAttempts.timestamps.push(now);
+  gameStateAttempts.set(userId, userAttempts);
+
+  return false;
+}
+


### PR DESCRIPTION
Throttle game state updates to a maximum of two per second, both client-side and server-side.

---
<a href="https://cursor.com/background-agent?bcId=bc-85c4bd3f-6a52-4473-bee5-8796875a209b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-85c4bd3f-6a52-4473-bee5-8796875a209b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

