### PR TITLE
Enhance trim modification

### DIFF
--- a/components/level/info/levelDropdown.tsx
+++ b/components/level/info/levelDropdown.tsx
@@ -18,7 +18,7 @@ import classNames from 'classnames';
 import Link from 'next/link';
 import { Fragment, useContext, useState } from 'react';
 import toast from 'react-hot-toast';
-import { trimLevel, simplifyLevelUnreachable } from '../../../helpers/transformLevel';
+import { trimLevel } from '../../../helpers/transformLevel';
 
 interface LevelDropdownProps {
   level: Level;
@@ -43,7 +43,6 @@ export default function LevelDropdown({ level }: LevelDropdownProps) {
   const isInPlayLater = !!(playLater?.[level._id.toString()]);
 
   const trimmable = trimLevel(level.data) != level.data;
-  const simplifiable = simplifyLevelUnreachable(level.data) != level.data;
 
   const modal = <ReportModal targetId={level._id.toString()} reportType={ReportType.LEVEL} />;
   const reportLevel = async () => {
@@ -232,7 +231,7 @@ export default function LevelDropdown({ level }: LevelDropdownProps) {
                   <span>Edit</span>
                 </div>
               </MenuItem>
-              {(trimmable || simplifiable) && <>
+              {trimmable && <>
                 <MenuItem>
                   <div
                     className={classNames('flex w-full items-center rounded-md cursor-pointer px-3 py-2 gap-3 hover-bg-3', { 'text-red-500': !isAuthor })}

--- a/components/level/info/levelDropdown.tsx
+++ b/components/level/info/levelDropdown.tsx
@@ -2,11 +2,11 @@ import { Menu, MenuButton, MenuItem, MenuItems, Transition } from '@headlessui/r
 import ArchiveLevelModal from '@root/components/modal/archiveLevelModal';
 import DeleteLevelModal from '@root/components/modal/deleteLevelModal';
 import EditLevelModal from '@root/components/modal/editLevelModal';
-import TrimLevelModal from '@root/components/modal/trimLevelModal';
 import PublishLevelModal from '@root/components/modal/publishLevelModal';
 import ReportModal from '@root/components/modal/reportModal';
 import SaveToCollectionModal from '@root/components/modal/saveToCollectionModal';
 import ShareModal from '@root/components/modal/shareModal';
+import TrimLevelModal from '@root/components/modal/trimLevelModal';
 import UnpublishLevelModal from '@root/components/modal/unpublishLevelModal';
 import { ReportType } from '@root/constants/ReportType';
 import { AppContext } from '@root/contexts/appContext';
@@ -15,6 +15,7 @@ import isCurator from '@root/helpers/isCurator';
 import isGuest from '@root/helpers/isGuest';
 import Level from '@root/models/db/level';
 import classNames from 'classnames';
+import { LucideFlipHorizontal2 } from 'lucide-react';
 import Link from 'next/link';
 import { Fragment, useContext, useState } from 'react';
 import toast from 'react-hot-toast';
@@ -240,11 +241,7 @@ export default function LevelDropdown({ level }: LevelDropdownProps) {
                       setPreventKeyDownEvent(true);
                     }}
                   >
-                    <svg xmlns='http://www.w3.org/2000/svg' className='w-5 h-5' viewBox='1 1 22 22' strokeWidth='1.5' stroke='currentColor' fill='none' strokeLinecap='round' strokeLinejoin='round'>
-                      <path stroke='none' d='M0 0h24v24H0z' fill='none' />
-                      <path d='M4 20h4l10.5 -10.5a2.828 2.828 0 1 0 -4 -4l-10.5 10.5v4' />
-                      <path d='M13.5 6.5l4 4' />
-                    </svg>
+                    <LucideFlipHorizontal2 className='w-5 h-5' />
                     <span>Trim</span>
                   </div>
                 </MenuItem>

--- a/components/modal/modifyModal.tsx
+++ b/components/modal/modifyModal.tsx
@@ -3,8 +3,6 @@ import Select, { CSSObjectWithLabel } from 'react-select';
 import * as transformLevel from '../../helpers/transformLevel';
 import Level from '../../models/db/level';
 import Modal from '.';
-import level from '@root/pages/api/level';
-import TileType from '@root/constants/tileType';
 
 interface ModifyModalProps {
   closeModal: () => void;
@@ -18,7 +16,7 @@ export default function ModifyModal({ closeModal, historyPush, isOpen, setIsDirt
   const [toTrim, setToTrim] = useState(true);
   const [toSimplify, setToSimplify] = useState(false);
   const [transformType, setTransformType] = useState('identity');
-  
+
   let simplifiable = false;
 
   function onSubmit() {

--- a/components/modal/modifyModal.tsx
+++ b/components/modal/modifyModal.tsx
@@ -3,6 +3,8 @@ import Select, { CSSObjectWithLabel } from 'react-select';
 import * as transformLevel from '../../helpers/transformLevel';
 import Level from '../../models/db/level';
 import Modal from '.';
+import level from '@root/pages/api/level';
+import TileType from '@root/constants/tileType';
 
 interface ModifyModalProps {
   closeModal: () => void;
@@ -14,7 +16,10 @@ interface ModifyModalProps {
 
 export default function ModifyModal({ closeModal, historyPush, isOpen, setIsDirty, setLevel }: ModifyModalProps) {
   const [toTrim, setToTrim] = useState(true);
+  const [toSimplify, setToSimplify] = useState(false);
   const [transformType, setTransformType] = useState('identity');
+  
+  let simplifiable = false;
 
   function onSubmit() {
     setLevel(prevLevel => {
@@ -27,9 +32,15 @@ export default function ModifyModal({ closeModal, historyPush, isOpen, setIsDirt
       // hold level data
       let data = level.data;
 
-      // trim first
+      // simplify first
+      if (toSimplify) {
+        data = transformLevel.simplifyLevelUnreachable(data);
+        simplifiable = data != level.data;
+      }
+
+      // then trim
       if (toTrim) {
-        data = transformLevel.trimLevel(level.data);
+        data = transformLevel.trimLevel(data);
       }
 
       // then transform
@@ -83,6 +94,17 @@ export default function ModifyModal({ closeModal, historyPush, isOpen, setIsDirt
             id='trim'
             name='trim'
             onChange={() => setToTrim(prevToTrim => !prevToTrim)}
+            type='checkbox'
+          />
+        </div>
+        <div className='flex flex-row gap-2 items-center w-full'>
+          <label className='font-semibold' htmlFor='simplify'>Simplify?</label>
+          <input
+            checked={toSimplify}
+            disabled={!simplifiable}
+            id='simplify'
+            name='simplify'
+            onChange={() => setToSimplify(prevToSimplify => !prevToSimplify)}
             type='checkbox'
           />
         </div>

--- a/components/modal/modifyModal.tsx
+++ b/components/modal/modifyModal.tsx
@@ -17,8 +17,6 @@ export default function ModifyModal({ closeModal, historyPush, isOpen, setIsDirt
   const [toSimplify, setToSimplify] = useState(false);
   const [transformType, setTransformType] = useState('identity');
 
-  let simplifiable = false;
-
   function onSubmit() {
     setLevel(prevLevel => {
       if (!prevLevel) {
@@ -33,7 +31,6 @@ export default function ModifyModal({ closeModal, historyPush, isOpen, setIsDirt
       // simplify first
       if (toSimplify) {
         data = transformLevel.simplifyLevelUnreachable(data);
-        simplifiable = data != level.data;
       }
 
       // then trim
@@ -99,7 +96,6 @@ export default function ModifyModal({ closeModal, historyPush, isOpen, setIsDirt
           <label className='font-semibold' htmlFor='simplify'>Simplify?</label>
           <input
             checked={toSimplify}
-            disabled={!simplifiable}
             id='simplify'
             name='simplify'
             onChange={() => setToSimplify(prevToSimplify => !prevToSimplify)}

--- a/components/modal/modifyModal.tsx
+++ b/components/modal/modifyModal.tsx
@@ -28,14 +28,14 @@ export default function ModifyModal({ closeModal, historyPush, isOpen, setIsDirt
       // hold level data
       let data = level.data;
 
-      // simplify first
-      if (toSimplify) {
-        data = transformLevel.simplifyLevelUnreachable(data);
-      }
-
-      // then trim
+      // trim first
       if (toTrim) {
         data = transformLevel.trimLevel(data);
+      }
+
+      // then simplify
+      if (toSimplify) {
+        data = transformLevel.simplifyLevelUnreachable(data);
       }
 
       // then transform

--- a/components/modal/publishLevelModal.tsx
+++ b/components/modal/publishLevelModal.tsx
@@ -8,6 +8,7 @@ import FormattedAuthorNote from '../formatted/formattedAuthorNote';
 import isNotFullAccountToast from '../toasts/isNotFullAccountToast';
 import Modal from '.';
 import SchedulePublishModal from './schedulePublishModal';
+import { trimLevel } from '../../helpers/transformLevel';
 
 interface PublishLevelModalProps {
   closeModal: () => void;
@@ -20,6 +21,10 @@ export default function PublishLevelModal({ closeModal, isOpen, level }: Publish
   const [isScheduleModalOpen, setIsScheduleModalOpen] = useState(false);
   const { mutateUser, user } = useContext(AppContext);
   const router = useRouter();
+
+  // these things are called a lot more often than I expected
+  // check if trimming would change the level
+  const trimmable = trimLevel(level.data) != level.data;
 
   function onConfirm() {
     setIsPublishing(true);
@@ -85,6 +90,9 @@ export default function PublishLevelModal({ closeModal, isOpen, level }: Publish
               </div>
             }
           </div>
+          {trimmable && <>
+            ⚠️ Full wall border; consider trimming.
+          </>}
           {/* Custom Button Row */}
           <div className='flex justify-center gap-3 pt-4'>
             <button

--- a/components/modal/publishLevelModal.tsx
+++ b/components/modal/publishLevelModal.tsx
@@ -3,12 +3,12 @@ import { useRouter } from 'next/router';
 import { useContext, useState } from 'react';
 import toast from 'react-hot-toast';
 import { AppContext } from '../../contexts/appContext';
+import { trimLevel } from '../../helpers/transformLevel';
 import Level from '../../models/db/level';
 import FormattedAuthorNote from '../formatted/formattedAuthorNote';
 import isNotFullAccountToast from '../toasts/isNotFullAccountToast';
 import Modal from '.';
 import SchedulePublishModal from './schedulePublishModal';
-import { trimLevel } from '../../helpers/transformLevel';
 
 interface PublishLevelModalProps {
   closeModal: () => void;
@@ -19,11 +19,9 @@ interface PublishLevelModalProps {
 export default function PublishLevelModal({ closeModal, isOpen, level }: PublishLevelModalProps) {
   const [isPublishing, setIsPublishing] = useState(false);
   const [isScheduleModalOpen, setIsScheduleModalOpen] = useState(false);
-  const { mutateUser, user } = useContext(AppContext);
+  const { mutateUser } = useContext(AppContext);
   const router = useRouter();
 
-  // these things are called a lot more often than I expected
-  // check if trimming would change the level
   const trimmable = trimLevel(level.data) != level.data;
   const [publishWithoutTrim, setPublishWithoutTrim] = useState(false);
 

--- a/components/modal/publishLevelModal.tsx
+++ b/components/modal/publishLevelModal.tsx
@@ -25,6 +25,7 @@ export default function PublishLevelModal({ closeModal, isOpen, level }: Publish
   // these things are called a lot more often than I expected
   // check if trimming would change the level
   const trimmable = trimLevel(level.data) != level.data;
+  const [publishWithoutTrim, setPublishWithoutTrim] = useState(false);
 
   function onConfirm() {
     setIsPublishing(true);
@@ -91,13 +92,22 @@ export default function PublishLevelModal({ closeModal, isOpen, level }: Publish
             }
           </div>
           {trimmable && <>
-            ⚠️ Full wall border; consider trimming.
+            <div className='flex flex-row gap-2 items-center w-full'>
+              <label className='font-semibold' htmlFor='trimmableWarning'>⚠️ Level can be trimmed. Publish anyway?</label>
+              <input
+                checked={publishWithoutTrim}
+                id='trimmableWarning'
+                name='trimmableWarning'
+                onChange={() => setPublishWithoutTrim(prevPublishWithoutTrim => !prevPublishWithoutTrim)}
+                type='checkbox'
+              />
+            </div>
           </>}
           {/* Custom Button Row */}
           <div className='flex justify-center gap-3 pt-4'>
             <button
               onClick={onConfirm}
-              disabled={isPublishing}
+              disabled={isPublishing || (trimmable && !publishWithoutTrim)}
               className='inline-flex justify-center px-6 py-2 text-sm font-medium border border-transparent rounded-md bg-blue-500 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed text-white'
             >
               {isPublishing ? 'Publishing...' : 'Publish Now'}
@@ -105,7 +115,7 @@ export default function PublishLevelModal({ closeModal, isOpen, level }: Publish
 
             <button
               onClick={onSchedule}
-              disabled={isPublishing}
+              disabled={isPublishing || (trimmable && !publishWithoutTrim)}
               className='inline-flex items-center justify-center gap-2 px-6 py-2 text-sm font-medium border border-transparent rounded-md bg-linear-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 disabled:opacity-50 disabled:cursor-not-allowed text-white'
             >
               <Image alt='pro' src='/pro.svg' width={16} height={16} className='opacity-90' />

--- a/components/modal/trimLevelModal.tsx
+++ b/components/modal/trimLevelModal.tsx
@@ -1,0 +1,105 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
+import Level from '../../models/db/level';
+import Modal from '.';
+
+interface TrimLevelModalProps {
+  closeModal: () => void;
+  isOpen: boolean;
+  level: Level;
+  onLevelUpdated?: (updatedLevel: Level) => void;
+}
+
+export default function TrimLevelModal({ closeModal, isOpen, level, onLevelUpdated }: TrimLevelModalProps) {
+  const [toTrim, setToTrim] = useState(true);
+  const [toSimplify, setToSimplify] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const router = useRouter();
+
+  function onSubmit() {
+    // No change so don't bother server
+    if (!toTrim && !toSimplify) {
+      toast.dismiss();
+      closeModal();
+      return;
+    }
+
+    setIsSubmitting(true);
+    toast.dismiss();
+    toast.loading('Updating level...');
+
+    fetch(`/api/level/${level._id}/trim`, {
+      method: 'PUT',
+      body: JSON.stringify({
+        trim: toTrim,
+        simplify: toSimplify,
+      }),
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    }).then(async res => {
+      if (res.status === 200) {
+        toast.dismiss();
+        toast.success('Updated');
+        closeModal();
+
+        const newLevel = await res.json();
+
+        if (newLevel) {
+          // Instead of reloading, update the level locally to preserve leastMoves
+          if (onLevelUpdated) {
+            onLevelUpdated(newLevel);
+          }
+
+          if (!newLevel.isDraft) {
+            router.replace(`/level/${newLevel.slug}`);
+          }
+          // Don't reload for draft levels - local update is sufficient
+        }
+      } else {
+        throw res.text();
+      }
+    }).catch(async err => {
+      console.error(err);
+      toast.dismiss();
+      toast.error(JSON.parse(await err)?.error);
+    }).finally(() => {
+      setIsSubmitting(false);
+    });
+  }
+
+  return (
+    <Modal
+      closeModal={closeModal}
+      disabled={isSubmitting}
+      isOpen={isOpen}
+      onSubmit={onSubmit}
+      title='Trim Level'
+    >
+      <div className='flex flex-col gap-2 max-w-full'>
+        <div className='flex flex-row gap-2 items-center w-full'>
+          <label className='font-semibold' htmlFor='trim'>Trim?</label>
+          <input
+            checked={toTrim}
+            id='trim'
+            name='trim'
+            onChange={() => setToTrim(prevToTrim => !prevToTrim)}
+            type='checkbox'
+          />
+        </div>
+        <div className='flex flex-row gap-2 items-center w-full'>
+          <label className='font-semibold' htmlFor='simplify'>Simplify?</label>
+          <input
+            checked={toSimplify}
+            id='simplify'
+            name='simplify'
+            onChange={() => setToSimplify(prevToSimplify => !prevToSimplify)}
+            type='checkbox'
+          />
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/components/modal/trimLevelModal.tsx
+++ b/components/modal/trimLevelModal.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import toast from 'react-hot-toast';
 import Level from '../../models/db/level';
 import Modal from '.';

--- a/components/modal/trimLevelModal.tsx
+++ b/components/modal/trimLevelModal.tsx
@@ -12,33 +12,17 @@ interface TrimLevelModalProps {
 }
 
 export default function TrimLevelModal({ closeModal, isOpen, level, onLevelUpdated }: TrimLevelModalProps) {
-  const [toTrim, setToTrim] = useState(true);
-  const [toSimplify, setToSimplify] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const router = useRouter();
 
   function onSubmit() {
-    // No change so don't bother server
-    if (!toTrim && !toSimplify) {
-      toast.dismiss();
-      closeModal();
-      return;
-    }
-
     setIsSubmitting(true);
     toast.dismiss();
     toast.loading('Updating level...');
 
     fetch(`/api/level/${level._id}/trim`, {
       method: 'PUT',
-      body: JSON.stringify({
-        trim: toTrim,
-        simplify: toSimplify,
-      }),
       credentials: 'include',
-      headers: {
-        'Content-Type': 'application/json'
-      }
     }).then(async res => {
       if (res.status === 200) {
         toast.dismiss();
@@ -78,28 +62,7 @@ export default function TrimLevelModal({ closeModal, isOpen, level, onLevelUpdat
       onSubmit={onSubmit}
       title='Trim Level'
     >
-      <div className='flex flex-col gap-2 max-w-full'>
-        <div className='flex flex-row gap-2 items-center w-full'>
-          <label className='font-semibold' htmlFor='trim'>Trim?</label>
-          <input
-            checked={toTrim}
-            id='trim'
-            name='trim'
-            onChange={() => setToTrim(prevToTrim => !prevToTrim)}
-            type='checkbox'
-          />
-        </div>
-        <div className='flex flex-row gap-2 items-center w-full'>
-          <label className='font-semibold' htmlFor='simplify'>Simplify?</label>
-          <input
-            checked={toSimplify}
-            id='simplify'
-            name='simplify'
-            onChange={() => setToSimplify(prevToSimplify => !prevToSimplify)}
-            type='checkbox'
-          />
-        </div>
-      </div>
+      Trimming this published level will be irreversible.
     </Modal>
   );
 }

--- a/helpers/transformLevel.ts
+++ b/helpers/transformLevel.ts
@@ -1,5 +1,5 @@
-import TileType from '@root/constants/tileType';
 import Direction, { directionToVector } from '@root/constants/direction';
+import TileType from '@root/constants/tileType';
 import Position from '@root/models/position';
 import TileTypeHelper from './tileTypeHelper';
 
@@ -132,14 +132,17 @@ export function simplifyLevelUnreachable(level: string) {
 
   // locate player (there doesn't seem to be an existing helper for this)
   let player = null;
+
   for (let y = 0; y < loadedLevel.length; y++) {
     for (let x = 0; x < loadedLevel[y].length; x++) {
       const tileType = loadedLevel[y][x] as TileType;
+
       if (tileType === TileType.Player || tileType === TileType.PlayerOnExit) {
         player = new Position(x, y);
       }
     }
   }
+
   if (player === null) {
     // player doesn't exist - prefer changing nothing
     return level;
@@ -149,44 +152,54 @@ export function simplifyLevelUnreachable(level: string) {
   function tileIfNotWallOrOOB(pos: Position) {
     // bounds checking, copied from gameStateHelpers.ts
     const row = loadedLevel[pos.y];
+
     if (!row || !row[pos.x]) {
       return null;
     }
+
     // treat wall same as oob
     const tile = row[pos.x];
+
     return tile === TileType.Wall ? null : tile;
   }
 
   // floodfill starting from player
-  let reachable = [player];
+  const reachable = [player];
   let fillIndex = -1;
+
   while (fillIndex < reachable.length - 1) {
     fillIndex++;
     const pos = reachable[fillIndex];
+
     for (const direction of [Direction.DOWN, Direction.LEFT, Direction.RIGHT, Direction.UP]) {
       const delta = directionToVector(direction);
       const nextPos = pos.add(delta);
       const nextTile = tileIfNotWallOrOOB(nextPos) as TileType;
+
       if (!nextTile) {
         // checking position is wall or oob
         continue;
       }
+
       if (TileTypeHelper.canMove(nextTile)) {
         // checking a block
         if (!TileTypeHelper.canMoveInDirection(nextTile, direction)) {
           // block acts as a wall from this direction
           continue;
         }
+
         const nextNextPos = nextPos.add(delta);
         const nextNextTile = tileIfNotWallOrOOB(nextNextPos);
+
         if (!nextNextTile) {
           // block would be pushed into wall or oob
           continue;
         }
       }
+
       // tile is 'walkable'
       // optimisation (unneeded): can avoid searching the list here and below using a bitarray of 'tile has been reached'
-      if (!reachable.some((seenPos) => {return seenPos.x == nextPos.x && seenPos.y == nextPos.y})) {
+      if (!reachable.some((seenPos) => {return seenPos.x == nextPos.x && seenPos.y == nextPos.y;})) {
         // and not queued
         reachable.push(nextPos);
       }
@@ -196,7 +209,7 @@ export function simplifyLevelUnreachable(level: string) {
   // turn anything not reachable to wall
   for (let y = 0; y < loadedLevel.length; y++) {
     for (let x = 0; x < loadedLevel[y].length; x++) {
-      if (!reachable.some((seenPos) => {return seenPos.x == x && seenPos.y == y})) {
+      if (!reachable.some((seenPos) => {return seenPos.x == x && seenPos.y == y;})) {
         loadedLevel[y][x] = TileType.Wall;
       }
     }

--- a/helpers/transformLevel.ts
+++ b/helpers/transformLevel.ts
@@ -2,7 +2,6 @@ import TileType from '@root/constants/tileType';
 import Direction, { directionToVector } from '@root/constants/direction';
 import Position from '@root/models/position';
 import TileTypeHelper from './tileTypeHelper';
-import trim from '@root/pages/api/level/[id]/trim';
 
 // convert raw level data into array of arrays
 function loadLevel(level: string) {

--- a/pages/api/level/[id]/trim/index.ts
+++ b/pages/api/level/[id]/trim/index.ts
@@ -1,0 +1,99 @@
+import { logger } from '@root/helpers/logger';
+import mongoose, { Types } from 'mongoose';
+import type { NextApiResponse } from 'next';
+import { ValidObjectId } from '../../../../../helpers/apiWrapper';
+import { enrichLevels } from '../../../../../helpers/enrich';
+import { generateLevelSlug } from '../../../../../helpers/generateSlug';
+import isCurator from '../../../../../helpers/isCurator';
+import cleanUser from '../../../../../lib/cleanUser';
+import withAuth, { NextApiRequestWithAuth } from '../../../../../lib/withAuth';
+import Level from '../../../../../models/db/level';
+import * as transformLevel from '../../../../../helpers/transformLevel';
+import { CollectionModel, LevelModel, UserModel } from '../../../../../models/mongoose';
+
+export default withAuth({
+  PUT: {
+    query: {
+      id: ValidObjectId(true),
+    },
+  },
+}, async (req: NextApiRequestWithAuth, res: NextApiResponse) => {
+  if (req.method === 'PUT') {
+    if (!req.body) {
+      return res.status(400).json({
+        error: 'Missing required fields',
+      });
+    }
+
+    const { id } = req.query;
+    const { trim, simplify } = req.body;
+
+    const level = await LevelModel.findById<Level>(id);
+
+    if (!level) {
+      return res.status(400).json({
+        error: 'Level not found',
+      });
+    }
+
+    if (isCurator(req.user) || req.userId === level.userId.toString()) {
+      // simplify, then trim the level
+      let data = level.data;
+      if (simplify) {
+        data = transformLevel.simplifyLevelUnreachable(data);
+      }
+      if (trim) {
+        data = transformLevel.trimLevel(data);
+      }
+      const newWidth = transformLevel.getWidth(data);
+      const newHeight = transformLevel.getHeight(data);
+      // check for a duplicate
+      if (await LevelModel.findOne({
+        data: data,
+        isDeleted: { $ne: true },
+        isDraft: false,
+        gameId: level.gameId,
+      })) {
+        return res.status(400).json({
+          error: `Level after modification is identical to another`,
+        });
+      }
+
+      // attempt to update the database
+      const session = await mongoose.startSession();
+
+      try {
+        await session.withTransaction(async () => {
+          await LevelModel.updateOne({
+            _id: id,
+          }, {
+            $set: {
+              data: data,
+              width: newWidth,
+              height: newHeight,
+            },
+          }, {
+            runValidators: true,
+            session: session,
+          });
+
+          // update level properties for return object
+          level.data = data;
+          level.width = newWidth;
+          level.height = newHeight;
+        });
+
+        session.endSession();
+      } catch (err) {
+        logger.error(err);
+        session.endSession();
+
+        return res.status(500).json({
+          error: `Error updating slug for level id ${level._id.toString()}`,
+        });
+      }
+    }
+
+    return res.status(200).json(level);
+  }
+});

--- a/pages/api/level/[id]/trim/index.ts
+++ b/pages/api/level/[id]/trim/index.ts
@@ -16,14 +16,7 @@ export default withAuth({
   },
 }, async (req: NextApiRequestWithAuth, res: NextApiResponse) => {
   if (req.method === 'PUT') {
-    if (!req.body) {
-      return res.status(400).json({
-        error: 'Missing required fields',
-      });
-    }
-
     const { id } = req.query;
-    const { trim, simplify } = req.body;
 
     const level = await LevelModel.findById<Level>(id);
 
@@ -34,14 +27,9 @@ export default withAuth({
     }
 
     if (isCurator(req.user) || req.userId === level.userId.toString()) {
-      // simplify, then trim the level
+      // trim the level
       let data = level.data;
-      if (simplify) {
-        data = transformLevel.simplifyLevelUnreachable(data);
-      }
-      if (trim) {
-        data = transformLevel.trimLevel(data);
-      }
+      data = transformLevel.trimLevel(data);
       const newWidth = transformLevel.getWidth(data);
       const newHeight = transformLevel.getHeight(data);
       // check for a duplicate
@@ -52,7 +40,7 @@ export default withAuth({
         gameId: level.gameId,
       })) {
         return res.status(400).json({
-          error: `Level after modification is identical to another`,
+          error: `Level after trimming is identical to another`,
         });
       }
 

--- a/pages/api/level/[id]/trim/index.ts
+++ b/pages/api/level/[id]/trim/index.ts
@@ -1,15 +1,12 @@
 import { logger } from '@root/helpers/logger';
-import mongoose, { Types } from 'mongoose';
+import mongoose from 'mongoose';
 import type { NextApiResponse } from 'next';
 import { ValidObjectId } from '../../../../../helpers/apiWrapper';
-import { enrichLevels } from '../../../../../helpers/enrich';
-import { generateLevelSlug } from '../../../../../helpers/generateSlug';
 import isCurator from '../../../../../helpers/isCurator';
-import cleanUser from '../../../../../lib/cleanUser';
 import withAuth, { NextApiRequestWithAuth } from '../../../../../lib/withAuth';
 import Level from '../../../../../models/db/level';
 import * as transformLevel from '../../../../../helpers/transformLevel';
-import { CollectionModel, LevelModel, UserModel } from '../../../../../models/mongoose';
+import { LevelModel } from '../../../../../models/mongoose';
 
 export default withAuth({
   PUT: {

--- a/tests/helpers/transformLevel.test.ts
+++ b/tests/helpers/transformLevel.test.ts
@@ -19,6 +19,11 @@ describe('helpers/transformLevel.ts', () => {
 
     expect(transformLevel.trimLevel(data)).toBe('40\n03');
   });
+  test('simplify', async () => {
+    const data = '1071\n1635\n1064';
+
+    expect(transformLevel.simplifyLevelUnreachable(data)).toBe('1111\n1135\n1064');
+  });
   test('symmetries', async () => {
     const data = 'E0\n00';
 

--- a/tests/helpers/transformLevel.test.ts
+++ b/tests/helpers/transformLevel.test.ts
@@ -24,10 +24,10 @@ describe('helpers/transformLevel.ts', () => {
 
     expect(transformLevel.simplifyLevelUnreachable(data)).toBe('111111111\n111111111\n114000011\n110010011\n110111011\n110010011\n110000011\n111111111\n111111111');
   });
-  test('simplifyKeepMoveableBlocks', async () => {
-    const data = '00000\n09560\n02790\n08470';
+  test('simplifyKeepMoveableBlocksNotPushedIntoWalls', async () => {
+    const data = '00080\n09569\n02799\n08471';
 
-    expect(transformLevel.simplifyLevelUnreachable(data)).toBe('00000\n09560\n02710\n08410');
+    expect(transformLevel.simplifyLevelUnreachable(data)).toBe('00080\n09569\n02791\n08411');
   });
   test('simplifySequence', async () => {
     const data = '1071\n1635\n1064';

--- a/tests/helpers/transformLevel.test.ts
+++ b/tests/helpers/transformLevel.test.ts
@@ -19,7 +19,17 @@ describe('helpers/transformLevel.ts', () => {
 
     expect(transformLevel.trimLevel(data)).toBe('40\n03');
   });
-  test('simplify', async () => {
+  test('simplifyFillHoles', async () => {
+    const data = '000000000\n001111100\n014000010\n010010010\n010101010\n010010010\n010000010\n001111100\n000000000';
+
+    expect(transformLevel.simplifyLevelUnreachable(data)).toBe('111111111\n111111111\n114000011\n110010011\n110111011\n110010011\n110000011\n111111111\n111111111');
+  });
+  test('simplifyKeepMoveableBlocks', async () => {
+    const data = '00000\n09560\n02790\n08470';
+
+    expect(transformLevel.simplifyLevelUnreachable(data)).toBe('00000\n09560\n02710\n08410');
+  });
+  test('simplifySequence', async () => {
     const data = '1071\n1635\n1064';
 
     expect(transformLevel.simplifyLevelUnreachable(data)).toBe('1111\n1135\n1064');


### PR DESCRIPTION
(This is the first github is seeing of this as I have talked a bit with sspenst on discord)

Add an option to 'simplify' a level when/instead of trimming that turns (most) provably non-interactable tiles into walls.
Added a warning and confirmation during publish if the level could be trimmed.
(TBD if wanted) Added an option to the level dropdown to trim/simplify the level if authorized and it would change the level - this could do with a well-worded description/warning considering the change is irreversible by the user. This cannot create duplicate levels.

NB: I tried running tests but many server/database related tests were failing.